### PR TITLE
_CommandType

### DIFF
--- a/edifice/components/button_view.py
+++ b/edifice/components/button_view.py
@@ -15,7 +15,7 @@ else:
         from PySide6.QtGui import QKeyEvent, QMouseEvent
         from PySide6.QtWidgets import QPushButton, QVBoxLayout, QHBoxLayout
 
-from ..base_components import View
+from ..base_components import View, _CommandType
 
 class _PushButton(QPushButton):
     def __init__(self):
@@ -96,6 +96,6 @@ class ButtonView(View):
         commands = super()._qt_update_commands(children, newprops, newstate)
         for prop in newprops:
             if prop == "on_trigger":
-                commands.append((self._set_on_trigger, self.underlying, newprops.on_trigger))
-            commands.append((self.underlying.setCursor, Qt.CursorShape.PointingHandCursor))
+                commands.append(_CommandType(self._set_on_trigger, self.underlying, newprops.on_trigger))
+            commands.append(_CommandType(self.underlying.setCursor, Qt.CursorShape.PointingHandCursor))
         return commands

--- a/edifice/components/image_aspect.py
+++ b/edifice/components/image_aspect.py
@@ -10,7 +10,7 @@ else:
     import PySide6.QtGui as QtGui
     import PySide6.QtWidgets as QtWidgets
 
-from ..base_components import QtWidgetElement, _image_descriptor_to_pixmap
+from ..base_components import QtWidgetElement, _image_descriptor_to_pixmap, _CommandType
 
 class ScaledLabel(QtWidgets.QLabel):
     """
@@ -68,5 +68,5 @@ class ImageAspect(QtWidgetElement):
         commands = super()._qt_update_commands(children, newprops, newstate, self.underlying, None)
         for prop in newprops:
             if prop == "src" and self.underlying is not None:
-                commands.append((self.underlying.setPixmap, _image_descriptor_to_pixmap(self.props.src)))
+                commands.append(_CommandType(self.underlying.setPixmap, _image_descriptor_to_pixmap(self.props.src)))
         return commands

--- a/edifice/components/table_grid_view.py
+++ b/edifice/components/table_grid_view.py
@@ -7,7 +7,7 @@ if QT_VERSION == "PyQt6" and not TYPE_CHECKING:
 else:
     from PySide6.QtWidgets import QGridLayout, QWidget
 
-from .._component import Element, BaseElement
+from .._component import Element, BaseElement, _CommandType
 from ..base_components import QtWidgetElement
 
 def _get_tablerowcolumn(c:Element) -> tuple[int,int]:
@@ -219,14 +219,14 @@ class TableGridView(QtWidgetElement):
         old_deletions = old_keys - new_keys
         new_additions = new_keys - old_keys
 
-        commands = []
+        commands: list[_CommandType] = []
         for row,column,_key in old_deletions:
-            commands.append((self._delete_child, self._widget_children_dict[(row,column,_key)], row, column))
+            commands.append(_CommandType(self._delete_child, self._widget_children_dict[(row,column,_key)], row, column))
             # Is this del doing anything?
             del self._widget_children_dict[(row,column,_key)]
 
         for row,column,_key in new_additions:
-            commands.append((self._add_child, newchildren[(row,column,_key)], row, column))
+            commands.append(_CommandType(self._add_child, newchildren[(row,column,_key)], row, column))
 
         self._widget_children_dict = newchildren
 
@@ -237,13 +237,13 @@ class TableGridView(QtWidgetElement):
         commands.extend(super()._qt_update_commands(children_of_rows, newprops, newstate, self.underlying, None))
         for prop in newprops:
             if prop == "row_stretch":
-                commands.append((self._set_row_stretch, newprops[prop]))
+                commands.append(_CommandType(self._set_row_stretch, newprops[prop]))
             elif prop == "column_stretch":
-                commands.append((self._set_column_stretch, newprops[prop]))
+                commands.append(_CommandType(self._set_column_stretch, newprops[prop]))
             elif prop == "row_minheight":
-                commands.append((self._set_row_minheight, newprops[prop]))
+                commands.append(_CommandType(self._set_row_minheight, newprops[prop]))
             elif prop == "column_minwidth":
-                commands.append((self._set_column_minwidth, newprops[prop]))
+                commands.append(_CommandType(self._set_column_minwidth, newprops[prop]))
 
         return commands
 

--- a/edifice/engine.py
+++ b/edifice/engine.py
@@ -306,7 +306,7 @@ class RenderResult(object):
 
     def run(self):
         for command in self.commands:
-            command[0](*command[1:])
+            command.fn(*command.args, **command.kwargs)
         self.render_context.run_callbacks()
 
 @dataclass

--- a/tests/test_base_component.py
+++ b/tests/test_base_component.py
@@ -6,6 +6,7 @@ import unittest
 import unittest.mock
 import edifice.engine as engine
 import edifice.base_components as base_components
+from edifice._component import _CommandType
 
 from edifice.qt import QT_VERSION
 if QT_VERSION == "PyQt6":
@@ -62,8 +63,8 @@ class StyleTestCase(unittest.TestCase):
         self.assertTrue("margin" not in style)
         self.assertCountEqual(
             commands,
-            [(layout.setContentsMargins, 10.0, 5.0, 5.0, 5.0),
-             (comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
+            [_CommandType(layout.setContentsMargins, 10.0, 5.0, 5.0, 5.0),
+             _CommandType(comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
         )
 
         style = {
@@ -78,8 +79,8 @@ class StyleTestCase(unittest.TestCase):
         self.assertTrue("margin" not in style)
         self.assertCountEqual(
             commands,
-            [(layout.setContentsMargins, 10, 9.0, 8, 9.0),
-             (comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
+            [_CommandType(layout.setContentsMargins, 10, 9.0, 8, 9.0),
+             _CommandType(comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
         )
 
     def test_align_layout(self):
@@ -97,8 +98,8 @@ class StyleTestCase(unittest.TestCase):
             self.assertTrue("align" not in style)
             self.assertCountEqual(
                 commands,
-                [(layout.setAlignment, qt_align),
-                 (comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
+                [_CommandType(layout.setAlignment, qt_align),
+                 _CommandType(comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
             )
         _test_for_align("left", QtCore.Qt.AlignmentFlag.AlignLeft)
         _test_for_align("right", QtCore.Qt.AlignmentFlag.AlignRight)
@@ -140,7 +141,7 @@ class StyleTestCase(unittest.TestCase):
         }
         comp = MockElement(style=style)
         commands = comp._gen_styling_commands([], style, None, None)
-        self.assertTrue((comp.underlying.move, 24, 12) in commands)
+        self.assertTrue(_CommandType(comp.underlying.move, x=24, y=12) in commands)
 
 
 class MockRenderContext(engine._RenderContext):
@@ -167,20 +168,21 @@ class WidgetTreeTestCase(unittest.TestCase):
         qt_button.font().pointSize()
         self.assertCountEqual(
             commands,
-            [(qt_button.setText, button_str), (qt_button.setStyleSheet, "QWidget#%s{}" % id(button)),
-             (qt_button.setProperty, "css_class", []),
-             (style.unpolish, qt_button),
-             (style.polish, qt_button),
-             (button._set_on_click, qt_button, on_click),
-             (button._set_on_key_down, qt_button, None),
-             (button._set_on_key_up, qt_button, None),
-             (button._set_on_mouse_enter, qt_button, None),
-             (button._set_on_mouse_leave, qt_button, None),
-             (button._set_on_mouse_down, qt_button, None),
-             (button._set_on_mouse_up, qt_button, None),
-             (button._set_on_mouse_move, qt_button, None),
-             (qt_button.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-             (qt_button.setCursor, QtCore.Qt.CursorShape.PointingHandCursor)
+            [_CommandType(qt_button.setText, button_str),
+             _CommandType(qt_button.setStyleSheet, "QWidget#%s{}" % id(button)),
+             _CommandType(qt_button.setProperty, "css_class", []),
+             _CommandType(style.unpolish, qt_button),
+             _CommandType(style.polish, qt_button),
+             _CommandType(button._set_on_click, qt_button, on_click),
+             _CommandType(button._set_on_key_down, qt_button, None),
+             _CommandType(button._set_on_key_up, qt_button, None),
+             _CommandType(button._set_on_mouse_enter, qt_button, None),
+             _CommandType(button._set_on_mouse_leave, qt_button, None),
+             _CommandType(button._set_on_mouse_down, qt_button, None),
+             _CommandType(button._set_on_mouse_up, qt_button, None),
+             _CommandType(button._set_on_mouse_move, qt_button, None),
+             _CommandType(qt_button.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+             _CommandType(qt_button.setCursor, QtCore.Qt.CursorShape.PointingHandCursor)
             ])
 
     def test_view_layout(self):
@@ -210,23 +212,24 @@ class WidgetTreeTestCase(unittest.TestCase):
         assert qt_icon is not None
         style = qt_icon.style()
         assert style is not None
+        assert icon.underlying is not None
         self.assertCountEqual(
             commands,
-            [(icon._render_image, ) + render_img_args,
-             (qt_icon.setStyleSheet, "QWidget#%s{}" % id(icon)),
-             (qt_icon.setProperty, "css_class", []),
-             (style.unpolish, icon.underlying),
-             (style.polish, icon.underlying),
-             (qt_icon.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-             (qt_icon.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
-             (icon._set_on_key_down, icon.underlying, None),
-             (icon._set_on_key_up, icon.underlying, None),
-             (icon._set_on_mouse_enter, icon.underlying, None),
-             (icon._set_on_mouse_leave, icon.underlying, None),
-             (icon._set_on_mouse_down, icon.underlying, None),
-             (icon._set_on_mouse_up, icon.underlying, None),
-             (icon._set_on_mouse_move, icon.underlying, None),
-             (icon._set_on_click, icon.underlying, None),
+            [_CommandType(icon._render_image, *render_img_args),
+             _CommandType(qt_icon.setStyleSheet, "QWidget#%s{}" % id(icon)),
+             _CommandType(qt_icon.setProperty, "css_class", []),
+             _CommandType(style.unpolish, icon.underlying),
+             _CommandType(style.polish, icon.underlying),
+             _CommandType(qt_icon.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+             _CommandType(qt_icon.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
+             _CommandType(icon._set_on_key_down, icon.underlying, None),
+             _CommandType(icon._set_on_key_up, icon.underlying, None),
+             _CommandType(icon._set_on_mouse_enter, icon.underlying, None),
+             _CommandType(icon._set_on_mouse_leave, icon.underlying, None),
+             _CommandType(icon._set_on_mouse_down, icon.underlying, None),
+             _CommandType(icon._set_on_mouse_up, icon.underlying, None),
+             _CommandType(icon._set_on_mouse_move, icon.underlying, None),
+             _CommandType(icon._set_on_click, icon.underlying, None),
             ])
         icon._render_image(*render_img_args)
 
@@ -250,41 +253,41 @@ class WidgetTreeTestCase(unittest.TestCase):
         label1.underlying.font().pointSize()
 
         self.assertCountEqual(commands, label1_commands + [
-            (view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
-            (view.underlying.setProperty, "css_class", []),
-            (view.underlying.style().unpolish, view.underlying),
-            (view.underlying.style().polish, view.underlying),
-            (view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-            (view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
-            (view._set_on_key_down, view.underlying, None),
-            (view._set_on_key_up, view.underlying, None),
-            (view._set_on_mouse_enter, view.underlying, None),
-            (view._set_on_mouse_leave, view.underlying, None),
-            (view._set_on_mouse_down, view.underlying, None),
-            (view._set_on_mouse_up, view.underlying, None),
-            (view._set_on_mouse_move, view.underlying, None),
-            (view._set_on_click, view.underlying, None),
-            (view._add_child, 0, label1.underlying)])
+            _CommandType(view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
+            _CommandType(view.underlying.setProperty, "css_class", []),
+            _CommandType(view.underlying.style().unpolish, view.underlying),
+            _CommandType(view.underlying.style().polish, view.underlying),
+            _CommandType(view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+            _CommandType(view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
+            _CommandType(view._set_on_key_down, view.underlying, None),
+            _CommandType(view._set_on_key_up, view.underlying, None),
+            _CommandType(view._set_on_mouse_enter, view.underlying, None),
+            _CommandType(view._set_on_mouse_leave, view.underlying, None),
+            _CommandType(view._set_on_mouse_down, view.underlying, None),
+            _CommandType(view._set_on_mouse_up, view.underlying, None),
+            _CommandType(view._set_on_mouse_move, view.underlying, None),
+            _CommandType(view._set_on_click, view.underlying, None),
+            _CommandType(view._add_child, 0, label1.underlying)])
 
         view_tree = engine._WidgetTree(view, [label1_tree, label2_tree])
         with engine._storage_manager() as manager:
             commands = view_tree.gen_qt_commands(MockRenderContext(manager, eng))
         self.assertCountEqual(commands, label1_commands + label2_commands + [
-            (view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
-            (view.underlying.setProperty, "css_class", []),
-            (view.underlying.style().unpolish, view.underlying),
-            (view.underlying.style().polish, view.underlying),
-            (view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-            (view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
-            (view._set_on_key_down, view.underlying, None),
-            (view._set_on_key_up, view.underlying, None),
-            (view._set_on_mouse_enter, view.underlying, None),
-            (view._set_on_mouse_leave, view.underlying, None),
-            (view._set_on_mouse_down, view.underlying, None),
-            (view._set_on_mouse_up, view.underlying, None),
-            (view._set_on_mouse_move, view.underlying, None),
-            (view._set_on_click, view.underlying, None),
-            (view._add_child, 1, label2.underlying)])
+            _CommandType(view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
+            _CommandType(view.underlying.setProperty, "css_class", []),
+            _CommandType(view.underlying.style().unpolish, view.underlying),
+            _CommandType(view.underlying.style().polish, view.underlying),
+            _CommandType(view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+            _CommandType(view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
+            _CommandType(view._set_on_key_down, view.underlying, None),
+            _CommandType(view._set_on_key_up, view.underlying, None),
+            _CommandType(view._set_on_mouse_enter, view.underlying, None),
+            _CommandType(view._set_on_mouse_leave, view.underlying, None),
+            _CommandType(view._set_on_mouse_down, view.underlying, None),
+            _CommandType(view._set_on_mouse_up, view.underlying, None),
+            _CommandType(view._set_on_mouse_move, view.underlying, None),
+            _CommandType(view._set_on_click, view.underlying, None),
+            _CommandType(view._add_child, 1, label2.underlying)])
 
         inner_view = base_components.View()
         old_child = view_tree.children[0].component
@@ -295,36 +298,36 @@ class WidgetTreeTestCase(unittest.TestCase):
         self.assertCountEqual(
             commands,
             label2_commands + [
-                (view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
-                (view.underlying.setProperty, "css_class", []),
-                (view.underlying.style().unpolish, view.underlying),
-                (view.underlying.style().polish, view.underlying),
-                (view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-                (view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
-                (view._set_on_key_down, view.underlying, None),
-                (view._set_on_key_up, view.underlying, None),
-                (view._set_on_mouse_enter, view.underlying, None),
-                (view._set_on_mouse_leave, view.underlying, None),
-                (view._set_on_mouse_down, view.underlying, None),
-                (view._set_on_mouse_up, view.underlying, None),
-                (view._set_on_mouse_move, view.underlying, None),
-                (view._set_on_click, view.underlying, None),
-                (inner_view.underlying.setStyleSheet, "QWidget#%s{}" % id(inner_view)),
-                (inner_view.underlying.setProperty, "css_class", []),
-                (inner_view.underlying.style().unpolish, inner_view.underlying),
-                (inner_view.underlying.style().polish, inner_view.underlying),
-                (inner_view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-                (inner_view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
-                (inner_view._set_on_key_down, inner_view.underlying, None),
-                (inner_view._set_on_key_up, inner_view.underlying, None),
-                (inner_view._set_on_mouse_enter, inner_view.underlying, None),
-                (inner_view._set_on_mouse_leave, inner_view.underlying, None),
-                (inner_view._set_on_mouse_down, inner_view.underlying, None),
-                (inner_view._set_on_mouse_up, inner_view.underlying, None),
-                (inner_view._set_on_mouse_move, inner_view.underlying, None),
-                (inner_view._set_on_click, inner_view.underlying, None),
-                (view._delete_child, 0, old_child),
-                (view._add_child, 1, inner_view.underlying)
+                _CommandType(view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
+                _CommandType(view.underlying.setProperty, "css_class", []),
+                _CommandType(view.underlying.style().unpolish, view.underlying),
+                _CommandType(view.underlying.style().polish, view.underlying),
+                _CommandType(view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+                _CommandType(view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
+                _CommandType(view._set_on_key_down, view.underlying, None),
+                _CommandType(view._set_on_key_up, view.underlying, None),
+                _CommandType(view._set_on_mouse_enter, view.underlying, None),
+                _CommandType(view._set_on_mouse_leave, view.underlying, None),
+                _CommandType(view._set_on_mouse_down, view.underlying, None),
+                _CommandType(view._set_on_mouse_up, view.underlying, None),
+                _CommandType(view._set_on_mouse_move, view.underlying, None),
+                _CommandType(view._set_on_click, view.underlying, None),
+                _CommandType(inner_view.underlying.setStyleSheet, "QWidget#%s{}" % id(inner_view)),
+                _CommandType(inner_view.underlying.setProperty, "css_class", []),
+                _CommandType(inner_view.underlying.style().unpolish, inner_view.underlying),
+                _CommandType(inner_view.underlying.style().polish, inner_view.underlying),
+                _CommandType(inner_view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+                _CommandType(inner_view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
+                _CommandType(inner_view._set_on_key_down, inner_view.underlying, None),
+                _CommandType(inner_view._set_on_key_up, inner_view.underlying, None),
+                _CommandType(inner_view._set_on_mouse_enter, inner_view.underlying, None),
+                _CommandType(inner_view._set_on_mouse_leave, inner_view.underlying, None),
+                _CommandType(inner_view._set_on_mouse_down, inner_view.underlying, None),
+                _CommandType(inner_view._set_on_mouse_up, inner_view.underlying, None),
+                _CommandType(inner_view._set_on_mouse_move, inner_view.underlying, None),
+                _CommandType(inner_view._set_on_click, inner_view.underlying, None),
+                _CommandType(view._delete_child, 0, old_child),
+                _CommandType(view._add_child, 1, inner_view.underlying)
             ])
 
 

--- a/tests/test_edifice.py
+++ b/tests/test_edifice.py
@@ -1,6 +1,7 @@
 import unittest
 import unittest.mock
 import edifice._component as component
+from edifice._component import _CommandType
 import edifice.engine as engine
 import edifice.base_components as base_components
 
@@ -168,7 +169,7 @@ class RenderTestCase(unittest.TestCase):
 
         def V(*args):
             view = qt_tree._dereference(args)
-            return [(view.component._add_child, i, child.component.underlying)
+            return [_CommandType(view.component._add_child, i, child.component.underlying)
                     for (i, child) in enumerate(view.children)]
 
         expected_commands = C(0, 0) + C(0, 1) + V(0) + C(0) + C(1, 0) + C(1, 1) + V(1) + C(1) + C(2) + V() + C()
@@ -193,20 +194,20 @@ class RenderTestCase(unittest.TestCase):
         render_result.trees[0]
         qt_commands = render_result.commands
         # TODO: Make it so that only the label (0, 0) needs to update!
-        expected_commands = [(qt_tree._dereference([0, 0]).component.underlying.setText, "AChanged")]
+        expected_commands = [_CommandType(qt_tree._dereference([0, 0]).component.underlying.setText, "AChanged")]
         self.assertEqual(qt_commands, expected_commands)
 
         component.state_b = "BChanged"
         render_result = app._request_rerender([component])
         qt_commands = render_result.commands
-        expected_commands = [(qt_tree._dereference([1, 0]).component.underlying.setText, "BChanged")]
+        expected_commands = [_CommandType(qt_tree._dereference([1, 0]).component.underlying.setText, "BChanged")]
         self.assertEqual(qt_commands, expected_commands)
 
         component.state_c = "CChanged"
         render_result = app._request_rerender([component])
         render_result.trees[0]
         qt_commands = render_result.commands
-        expected_commands = [(qt_tree._dereference([2]).component.underlying.setText, "CChanged")]
+        expected_commands = [_CommandType(qt_tree._dereference([2]).component.underlying.setText, "CChanged")]
         self.assertEqual(qt_commands, expected_commands)
 
     def test_keyed_list_add(self):
@@ -223,14 +224,14 @@ class RenderTestCase(unittest.TestCase):
 
         def new_V(*args):
             view = _new_qt_tree._dereference(args)
-            return [(view.component._add_child, i, child.component.underlying)
+            return [_CommandType(view.component._add_child, i, child.component.underlying)
                     for (i, child) in enumerate(view.children)]
 
         self.assertEqual(_new_qt_tree._dereference([2, 0]).component.props.text, "D")
         def new_C(*args):
             return _commands_for_address(_new_qt_tree, args)
         expected_commands = (new_C(2, 0) + new_C(2, 1) + new_V(2) + new_C(2) +
-                             [(qt_tree.component._add_child, 2, _new_qt_tree.children[2].component.underlying)])
+                             [_CommandType(qt_tree.component._add_child, 2, _new_qt_tree.children[2].component.underlying)])
 
         self.assertEqual(qt_commands, expected_commands)
 
@@ -249,8 +250,8 @@ class RenderTestCase(unittest.TestCase):
         qt_commands = render_result.commands
 
         expected_commands = (
-                             [(qt_tree.component._add_child, 0, qt_tree.children[2].component.underlying)]
-                             + [(qt_tree.component._add_child, 1, qt_tree.children[1].component.underlying)])
+            [_CommandType(qt_tree.component._add_child, 0, qt_tree.children[2].component.underlying)]
+            + [_CommandType(qt_tree.component._add_child, 1, qt_tree.children[1].component.underlying)])
 
         self.assertEqual(qt_commands, expected_commands)
 
@@ -266,7 +267,10 @@ class RenderTestCase(unittest.TestCase):
         _new_qt_tree = render_result.trees[0]
         qt_commands = render_result.commands
 
-        expected_commands = [(qt_tree._dereference([0, 0]).component.underlying.setText, "C"), (qt_tree._dereference([2, 0]).component.underlying.setText, "A")]
+        expected_commands = [
+            _CommandType(qt_tree._dereference([0, 0]).component.underlying.setText, "C"),
+            _CommandType(qt_tree._dereference([2, 0]).component.underlying.setText, "A"),
+        ]
         self.assertEqual(qt_commands, expected_commands)
 
     def test_keyed_list_delete_child(self):
@@ -282,7 +286,7 @@ class RenderTestCase(unittest.TestCase):
         _new_qt_tree = render_result.trees[0]
         qt_commands = render_result.commands
 
-        expected_commands = [(qt_tree.component._delete_child, 2, old_child)]
+        expected_commands = [_CommandType(qt_tree.component._delete_child, 2, old_child)]
 
         self.assertEqual(qt_commands, expected_commands)
 


### PR DESCRIPTION
The _CommandType previously didn't have any correspondence between the function being called and the arguments in the tuple. This commit changes the type `_CommandType` to be a class that ensures that the arguments can be passed to the function in the head of the argument list.