### PR TITLE
use_ref, use_effect, use_state improvements

### DIFF
--- a/docs/source/edifice.rst
+++ b/docs/source/edifice.rst
@@ -15,9 +15,6 @@ Class overview
    :template: custom-class.rst
 
    Element
-   PropsDict
-   register_props
    component
    Reference
    App
-   Timer

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -245,7 +245,6 @@ Table of Contents
    edifice
    base_components
    compound_components
-   state
    hooks
    utilities
    styling

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -48,17 +48,6 @@ First we define a function :code:`MyApp` which is decorated by
 :func:`edifice.component`.
 The :code:`MyApp` component is the top-level Element of our application.
 
-A component is a function which, when called, renders an Element tree.
-Some Elements may have children. The children are other Elements.
-
-The rendering for an Edifice application is done by declaring a tree of Elements
-starting with a single root Element, and then declaring its children.
-
-An Element may be either a component function, or a base
-:class:`QtWidgetElement <edifice.QtWidgetElement>`.
-
-The base QtWidgetElements, when rendered, update their underlying QtWidget.
-
 :class:`View<edifice.View>` is an example of
 a base :class:`QtWidgetElement <edifice.QtWidgetElement>`.
 The View receives :code:`layout="row"` as an argument in its constructor.

--- a/edifice/__init__.py
+++ b/edifice/__init__.py
@@ -3,68 +3,43 @@ An edifice application is created by rendering a :class:`Element` with an
 :class:`App`.
 Let's examine what these objects are to understand what this statement means.
 
-Elements are the basic building blocks of your GUI.
-A Element object is a stateful container wrapping a stateless render function,
-which describes what to render given the current Element state.
-Elements can be composed of other components,
-both native components
-(:class:`View`, :class:`Button`, :class:`Label`)
-and other composite Elements created by you or others.
+The rendering for an Edifice application is done by declaring a tree of Elements
+starting with a single root Element, and then declaring its children.
+
+An Element may be either a
+:doc:`Base Element <base_components>`
+or a :func:`component` Element.
+
+A :func:`component` Element is a function which renders an
+:class:`Element` tree.
 
 Elements have both internal state and external properties.
-The external properties, **props**, are passed into the Element by another
-Element::
+The external properties, **props**, are passed into the Element::
 
-    class Foo(Element):
-        def __init__(self, a, b, c):  # a, b, c are the props
-            self.register_props({"a": a, "b": b, "c": c})  # don't worry about this for now
-            pass
+    @component
+    def Foo(self, a, b, c): # a, b, c are the props
 
-    Foo(a=1, b=2, c=3)  # Create a Foo with props a=1, b=2, c=3.
+    Foo(a=1, b=2, c=3)  # Render a Foo with props a=1, b=2, c=3.
 
 These values are owned by the external caller and should not be modified by this Element.
-They may be accessed via the field props :code:`self.props`, which is a
-:class:`PropsDict`.
-A :class:`PropsDict` allows iteration, “get item” :code:`self.props["value"]`,
-and “get attribute” :code:`self.props.value`, but not “set item” or “set attribute”.
 
 The internal state, henceforth referred to as the **state**, belong to the Element.
-These are attributes of the Element object, for instance :code:`self.my_state`.
-You can initialize the state as usual in the constructor
-(e.g. :code:`self.my_state = {"a": 1}`),
-and the state persists so long as the Element is still mounted.
+In a :func:`component` Element, the internal state is managed by :doc:`hooks`.
 
-Changes in state and props will automatically trigger a re-render
-(unless you override this behavior by modifying :func:`Element.should_update`).
-State should be changed using either the :func:`Element.set_state` function
-or the :func:`Element.render_changes` context manager.
-See documentation for :class:`Element` for more details.
+Changes in **state** or **props** will automatically trigger a re-render.
 
-The main method of Element is :func:`Element.render`, which should describe the rendered UI
-given the current Element state.
-The render result is composed of your own higher-level components as well as
-the core Elements, such as
-:class:`Label`, :class:`Button`, and :class:`View`.
-Elements may be composed in a tree like fashion:
-one special prop is :code:`children`, which will always be defined (defaults to an
-empty list).
-To better enable the visualization of the tree-structure of a Element
-in the code,
-the :code:`call()` method of Element has been overriden to set the arguments
-of the call as children of the component.
-This allows you to write tree-like code remniscent of HTML::
+Declaring an Element tree in a :func:`component` Element render function looks
+like this::
 
-    def render(self):
-        return View(layout="column")(
-            View(layout="row")(
-                Label("Username: "),
+    @component
+    def MyApp(self):
+        with View(layout="column"):
+            with View(layout="row"):
+                Label("Username: ")
                 TextInput()
-            ),
-            View(layout="row")(
-                Label("Email: "),
+            with View(layout="row"):
+                Label("Email: ")
                 TextInput()
-            ),
-        )
 
 In HTML/XML, this would be written as:
 
@@ -81,41 +56,27 @@ In HTML/XML, this would be written as:
     </View>
 
 You can thus describe your entire application as a single root Element,
-which is composed of various sub-components representing different parts of your application.
+which is composed of various sub-Elements representing different parts of your application.
 Each Element is responsible for managing its own state,
 updating it as necessary given user interactions and events.
 Because state is self-contained, you can compose Elements arbitarily,
 including across projects.
-Edifice provides a few higher level components that are defined using the
-same API provided to users.
 
-One central tenet of Edifice is the importance of managing state.
-The most complex part of any application is not fancy widgets or animations,
-but maintaining consistent state, so that what the user sees is accurate
-(this is very important -- you don't want to show Apple stock prices
-when other parts of your UI indicates the user is looking at Microsoft!)
-The Element abstraction ensures that the UI is a pure and side effect free
-function of the state, so that if you serialize the state and play it back,
-you get the same UI.
+Edifice, like React, uses the `Elm Architecture <https://guide.elm-lang.org/architecture/>`_,
+also known as Model-View-Update.
+This means that there is a one-way information flow from Model to View to
+Update and then back to Model.
 
-Of course, we don't live in a functional utopia devoid of any mutable state,
-so equally important is managing ownership of the state.
-There should be only one ground truth value for any state variable,
-and any copies of this state should always refer back to the ground truth value.
-In the simplest case, state is managed by a Element,
-and passed down to children through props.
-The child cannot modify the prop directly; doing so would result in two different values of the state.
-In order for a child component to modify state in the parent,
-the parent has to pass a setter function to the child,
-so that any change is done on the ground truth source.
-For cases where some central state is shared across
-a wide swath of UI components, e.g. currently logged in user,
-Edifice provides
-:doc:`state values and state managers <state>` to allow this state
-to be shared across many different components with the same reactive guarantee:
-all state changes will be reflected in the UI.
+====== =======
+Model  The **state** of the application.
+View   The declarative render function.
+Update Event handlers which change the **state**.
+====== =======
 
-An App object encapsulates the rendering engine that's responsible
+It is the one-way information flow of Model-View-Update which makes
+this style of GUI programming scale up well to complicated user interfaces.
+
+An :class:`App` encapsulates the rendering engine that's responsible
 for issuing the commands necessary to render the each of the declared Elements.
 The :class:`App` object is created by passing in the root :class:`Element`,
 and it tracks all state changes in the Element tree with the given root.
@@ -125,11 +86,11 @@ and display the GUI you created::
     if __name__ == "__main__":
         App(MyApp()).start()
 
-When components are rendered, the :func:`Element.render` function is called.
-This output is then compared against the output
+When Elements are rendered,
+the result is then compared against the result
 of the previous render (if that exists). The two renders are diffed,
 and on certain conditions, the Element objects from the previous render
-are maintained and updated with new props.
+are updated with new props.
 Two Elements belonging to different classes will always be re-rendered,
 and Elements belonging to the same class are assumed to be the same
 and thus maintained (preserving the old state).
@@ -137,22 +98,11 @@ and thus maintained (preserving the old state).
 For lists of Elements, a more complex procedure (the same as in ReactJS)
 will determine which Elements to maintain and which to replace;
 see documentation of :class:`Element` class for details.
-
-Some useful utilities are also provided:
-
-* :func:`register_props` : A decorator for the :code:`__init__` function that records
-  all arguments as props.
-* :func:`component`: A decorator to turn a render function into a
-  Element. This is useful if your Element has no internal state.
-* :func:`edifice.utilities.set_trace`: An analogue of :code:`pdb.set_trace` that works with Qt
-  (:code:`pdb.set_trace` interrupts the Qt event flow, causing an unpleasant
-  debugging experience). Use this :code:`set_trace` if you want to set breakpoings.
 """
 
 
-from ._component import PropsDict, Element, component, Reference
-from .state import StateValue, StateManager
+from ._component import Element, component, Reference
 from .app import App
 from .base_components import *
-from .utilities import alert, file_dialog, Timer, set_trace
-from .hooks import use_state, use_effect, use_async
+from .utilities import alert, file_dialog, set_trace
+from .hooks import use_state, use_effect, use_async, use_ref

--- a/edifice/base_components/__init__.py
+++ b/edifice/base_components/__init__.py
@@ -1,19 +1,25 @@
 """
-Base Elements are the building blocks for your Edifice application.
-These components may all be imported from the edifice namespace::
+Base Elements are the building blocks for an Edifice application.
 
-    import edifice
-    from edifice import View, Label
+Each
+Base Element manages an underlying
+`QWidget <https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QWidget.html>`_.
 
-    # you can now access edifice.Button, View, etc.
+If the Base Element is a layout, then it also manages an underlying
+`QLayout <https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QLayout.html>`_,
+and it can have children.
 
-All components in this module inherit from :class:`QtWidgetElement<edifice.QtWidgetElement>`
+When the base Element renders, it adjusts the properties of the
+underlying QWidget and QLayout.
+
+All Elements in this module inherit from :class:`QtWidgetElement<edifice.QtWidgetElement>`
 and its props, such as :code:`style` and :code:`on_click`.
-This means that all widgets could potentially respond to clicks and are stylable using css-like stylesheets.
+This means that all Elements can respond to clicks and are stylable using
+:code:`style` prop and `Qt Style Sheets <https://doc.qt.io/qtforpython-6/overviews/stylesheet-reference.html>`_.
 
-The components here can roughly be divided into layout components and content components.
+Base Element can roughly be divided into layout Elements and leaf Elements.
 
-Layout components take a list of children and function as a container for its children;
+Layout Elements take a list of children and function as a container for its children;
 it is most analogous to the :code:`<div>` html tag.
 The two basic layout components are :class:`View<edifice.View>` and :class:`ScrollView<edifice.ScrollView>`.
 They take a layout prop, which controls whether children are laid out in a row,

--- a/edifice/base_components/base_components.py
+++ b/edifice/base_components/base_components.py
@@ -159,7 +159,7 @@ class QtWidgetElement(WidgetElement):
     Args:
         style: style for the widget. Could either be a dictionary or a list of dictionaries.
 
-            See :doc:`<styling>` for a primer on styling.
+            See :doc:`../../styling` for a primer on styling.
         tool_tip:
             the tool tip displayed when hovering over the widget.
         cursor:
@@ -223,7 +223,11 @@ class QtWidgetElement(WidgetElement):
             as argument.
 
     """
+
     underlying: _UnderlyingType | None
+    """
+    The underlying QWidget, which may not exist if this Element has not rendered.
+    """
 
     def __init__(
         self,

--- a/edifice/hooks.py
+++ b/edifice/hooks.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Coroutine
-from edifice._component import get_render_context_maybe, _T_use_state
+from edifice._component import get_render_context_maybe, _T_use_state, Reference
 from typing import Any
 
 def use_state(initial_state:_T_use_state) -> tuple[
@@ -56,7 +56,7 @@ def use_state(initial_state:_T_use_state) -> tuple[
     updates will be cancelled and the state value will be unchanged for the
     next render.
 
-	.. warning::
+    .. warning::
         You can't store a :code:`callable` value in :code:`use_state`,
         because it will be mistaken for an **updater function**. If you
         want to store a :code:`callable` value, like a function, then wrap
@@ -85,6 +85,22 @@ def use_effect(
 
     Behaves like `React useEffect <https://react.dev/reference/react/useEffect>`_.
 
+    The **setup function** will be called after render and after the underlying
+    Qt Widgets are updated.
+
+    The **cleanup function** will be called by Edifice exactly once for
+    each call to the **setup function**.
+    The **cleanup function**
+    is called after render and before the component is deleted.
+
+    If the dependencies change, then the old **cleanup function** is called and
+    then the new **setup function** is called.
+
+    If the **setup function** raises an Exception then the
+    **cleanup function** will not be called.
+    Exceptions raised from the **setup function** and **cleanup function**
+    will be suppressed.
+
     Example::
 
         @component
@@ -100,12 +116,6 @@ def use_effect(
 
     Args:
         setup: An effect **setup function** which returns a **cleanup function**.
-
-            The **cleanup function** will be called by Edifice exactly once for
-            each call to the **setup function**.
-
-            If the **setup function** raises an Exception then the
-            **cleanup function** will not be called.
         dependencies: The effect **setup function** will be called when the
             dependencies are not :code:`__eq__` to the old dependencies.
     Returns:
@@ -171,3 +181,10 @@ def use_async(
     if context is None:
         raise ValueError("use_async used outside component")
     return context.use_async(fn_coroutine, dependencies)
+
+def use_ref() -> Reference:
+    """
+    Hook for creating a :class:`Reference` in a :func:`edifice.component` function.
+    """
+    r,_ = use_state(Reference())
+    return r

--- a/edifice/inspector/inspector.py
+++ b/edifice/inspector/inspector.py
@@ -1,11 +1,12 @@
 import inspect
 import edifice as ed
+from edifice.state import StateManager
 
 
 SELECTION_COLOR = "#ACCEF7"
 
 
-current_selection = ed.StateManager({
+current_selection = StateManager({
 })
 
 

--- a/examples/use_ref1.py
+++ b/examples/use_ref1.py
@@ -1,0 +1,28 @@
+#
+# python examples/use_ref1.py
+#
+
+import asyncio as asyncio
+import sys, os
+# We need this sys.path line for running this example, especially in VSCode debugger.
+sys.path.insert(0, os.path.join(sys.path[0], '..'))
+from edifice import App, View, Label, Button, component, use_ref, use_effect
+
+@component
+def MyComp(self):
+    ref = use_ref()
+
+    def did_render():
+        if ref:
+            ref().underlying.setText("Hi")
+        return lambda:None
+
+    use_effect(did_render, ref)
+
+    with View():
+        Label("Hi").register_ref(ref)
+
+if __name__ == "__main__":
+    my_app = App(MyComp())
+    with my_app.start_loop() as loop:
+        loop.run_forever()

--- a/tests/components/test_forms.py
+++ b/tests/components/test_forms.py
@@ -5,6 +5,7 @@ import enum
 
 import edifice
 from edifice.components import forms
+from edifice.state import StateManager
 
 from edifice.qt import QT_VERSION
 if QT_VERSION == "PyQt6":
@@ -21,7 +22,7 @@ class FormTest(unittest.TestCase):
         class Color(enum.Enum):
             RED = 1,
             BLUE = 2,
-        data = edifice.StateManager({
+        data = StateManager({
             "a": 1,
             "b": "b",
             "c": 1.0,
@@ -53,7 +54,7 @@ class FormTest(unittest.TestCase):
         class Color(enum.Enum):
             RED = 1,
             BLUE = 2,
-        data = edifice.StateManager({
+        data = StateManager({
             "a": 1,
             "b": "b",
             "c": 1.0,
@@ -87,7 +88,7 @@ class FormTest(unittest.TestCase):
         self.assertEqual(data["d"], (3, [1, 2, 3, 4]))
 
     def test_reset(self):
-        data = edifice.StateManager({
+        data = StateManager({
             "a": 1,
             "b": 2,
             "c": 3,


### PR DESCRIPTION
Add `use_ref`.

Fix `use_effect` so that the effects run “after render.”

Fix `use_state` so that the states are only reduced once before the render.

Also docs.