### PR TITLE
allow `use_effect` to not define cleanup

### DIFF
--- a/edifice/_component.py
+++ b/edifice/_component.py
@@ -245,7 +245,7 @@ class RenderContextProtocol(tp.Protocol):
         ...
     def use_effect(
         self,
-        setup: Callable[[], Callable[[], None]],
+        setup: Callable[[], Callable[[], None] | None],
         dependencies: tp.Any,
     ) -> None:
         ...

--- a/edifice/engine.py
+++ b/edifice/engine.py
@@ -308,7 +308,7 @@ class _HookState:
 
 @dataclass
 class _HookEffect:
-    setup: tp.Callable[[], tp.Callable[[], None]] | None
+    setup: tp.Callable[[], tp.Callable[[], None] | None] | None
     cleanup: tp.Callable[[], None] | None
     """
     Cleanup function called on unmount and overwrite

--- a/edifice/hooks.py
+++ b/edifice/hooks.py
@@ -109,7 +109,7 @@ def use_state(initial_state:_T_use_state) -> tuple[
 
 
 def use_effect(
-    setup: Callable[[], Callable[[], None]],
+    setup: Callable[[], Callable[[], None] | None],
     dependencies: Any,
 ) -> None:
     """


### PR DESCRIPTION
If the `None` is returned from the `setup` function it is equivalent to not performing any cleanup at all.

Closes #91 