### PR TITLE
Diffing and reconciliation

### DIFF
--- a/edifice/_component.py
+++ b/edifice/_component.py
@@ -711,11 +711,21 @@ def Container(self):
 
 class BaseElement(Element):
     """Base Element, whose rendering is defined by the backend."""
+    # TODO _qt_update_commands should be a virtual function but _WidgetTree
+    # isn't defined here.
+    #
+    # def _qt_update_commands(
+    #     self,
+    #     children: list[_WidgetTree],
+    #     newprops : PropsDict,
+    #     newstate,
+    #     underlying: QtWidgets.QWidget,
+    #     underlying_layout: QtWidgets.QLayout | None = None
+    # ) -> list[_CommandType]:
+    #     raise NotImplementedError
+
 
 class WidgetElement(BaseElement):
-    pass
-
-class LayoutElement(BaseElement):
     pass
 
 

--- a/edifice/app.py
+++ b/edifice/app.py
@@ -239,9 +239,10 @@ class App(object):
         if self._inspector_component is not None and not all(isinstance(comp, inspector.InspectorElement) for comp in components):
             self._inspector_component._refresh()
 
-        self._is_rerenderding = False
         if len(self._defer_rerender_elements) > 0:
             asyncio.get_event_loop().call_soon(self._rerender_callback)
+        else:
+            self._is_rerenderding = False
 
     def set_stylesheet(self, stylesheet):
         """Adds a global stylesheet for the app.

--- a/edifice/app.py
+++ b/edifice/app.py
@@ -210,9 +210,9 @@ class App(object):
         Enqueue elements for rerendering on the next event loop iteration.
         Idempotent.
         """
-        self._defer_rerender_elements.update(components)
-        if not self._is_rerenderding:
+        if not self._is_rerenderding and len(self._defer_rerender_elements) == 0:
             asyncio.get_event_loop().call_soon(self._rerender_callback)
+        self._defer_rerender_elements.update(components)
 
     def _request_rerender(self, components: list[Element], newstate):
         """

--- a/edifice/app.py
+++ b/edifice/app.py
@@ -195,7 +195,7 @@ class App(object):
         self._inspector_component = None
 
         self._defer_rerender_elements : set[Element] = set()
-        self._is_rerenderding = False
+        self._is_rerendering = False
 
     def __hash__(self):
         return id(self)
@@ -210,18 +210,18 @@ class App(object):
         Enqueue elements for rerendering on the next event loop iteration.
         Idempotent.
         """
-        if not self._is_rerenderding and len(self._defer_rerender_elements) == 0:
+        if not self._is_rerendering and len(self._defer_rerender_elements) == 0:
             asyncio.get_event_loop().call_soon(self._rerender_callback)
         self._defer_rerender_elements.update(components)
         # Since we know that we are going to rerender, we can immediately
         # start buffering the _defer_rerender calls with _is_rerendering=True.
-        self._is_rerenderding = True
+        self._is_rerendering = True
 
     def _request_rerender(self, components: list[Element], newstate):
         """
         Call the RenderEngine to immediately render the widget tree.
         """
-        self._is_rerenderding = True
+        self._is_rerendering = True
         del newstate #TODO?
         start_time = time.process_time()
 
@@ -242,7 +242,7 @@ class App(object):
         if len(self._defer_rerender_elements) > 0:
             asyncio.get_event_loop().call_soon(self._rerender_callback)
         else:
-            self._is_rerenderding = False
+            self._is_rerendering = False
 
     def set_stylesheet(self, stylesheet):
         """Adds a global stylesheet for the app.

--- a/edifice/app.py
+++ b/edifice/app.py
@@ -194,34 +194,28 @@ class App(object):
         self._inspector = inspector
         self._inspector_component = None
 
-        self._defer_rerender_elements : set[Element] = set()
-        self._is_rerendering = False
+        self._pending_rerender = False
 
     def __hash__(self):
         return id(self)
 
     def _rerender_callback(self):
-        els = self._defer_rerender_elements.copy()
-        self._defer_rerender_elements.clear()
-        self._request_rerender(list(els), {})
+        self._pending_rerender = False
+        self._request_rerender([], {})
 
-    def _defer_rerender(self, components: list[Element]):
+    def _defer_rerender(self):
         """
-        Enqueue elements for rerendering on the next event loop iteration.
+        Rerender on the next event loop iteration.
         Idempotent.
         """
-        if not self._is_rerendering and len(self._defer_rerender_elements) == 0:
+        if not self._pending_rerender:
             asyncio.get_event_loop().call_soon(self._rerender_callback)
-        self._defer_rerender_elements.update(components)
-        # Since we know that we are going to rerender, we can immediately
-        # start buffering the _defer_rerender calls with _is_rerendering=True.
-        self._is_rerendering = True
+        self._pending_rerender = True
 
     def _request_rerender(self, components: list[Element], newstate):
         """
         Call the RenderEngine to immediately render the widget tree.
         """
-        self._is_rerendering = True
         del newstate #TODO?
         start_time = time.process_time()
 
@@ -238,11 +232,6 @@ class App(object):
 
         if self._inspector_component is not None and not all(isinstance(comp, inspector.InspectorElement) for comp in components):
             self._inspector_component._refresh()
-
-        if len(self._defer_rerender_elements) > 0:
-            asyncio.get_event_loop().call_soon(self._rerender_callback)
-        else:
-            self._is_rerendering = False
 
     def set_stylesheet(self, stylesheet):
         """Adds a global stylesheet for the app.

--- a/edifice/app.py
+++ b/edifice/app.py
@@ -1,5 +1,5 @@
 import logging
-
+from . import logger as _logger_module
 import asyncio
 import contextlib
 import os
@@ -25,8 +25,7 @@ from .base_components import Window, QtWidgetElement, ExportList
 from .engine import RenderEngine
 from .inspector import inspector
 
-logger = logging.getLogger("Edifice")
-logger_mod = logger
+logger = _logger_module.logger
 
 BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, WHITE = range(8)
 
@@ -87,6 +86,16 @@ class App(object):
     This widget can then be plugged into the rest of your application, and there's no need
     to manage the rendering of the widget -- state changes will trigger automatic re-render
     without any intervention.
+
+    Logging
+    -------
+
+    To enable Edifice logging set the logging level. Example::
+
+        import logging
+        logger = logging.getLogger("Edifice")
+        logger.setLevel(logging.INFO)
+
 
     Args:
         root_element: the root Element of the application.

--- a/edifice/app.py
+++ b/edifice/app.py
@@ -213,6 +213,9 @@ class App(object):
         if not self._is_rerenderding and len(self._defer_rerender_elements) == 0:
             asyncio.get_event_loop().call_soon(self._rerender_callback)
         self._defer_rerender_elements.update(components)
+        # Since we know that we are going to rerender, we can immediately
+        # start buffering the _defer_rerender calls with _is_rerendering=True.
+        self._is_rerenderding = True
 
     def _request_rerender(self, components: list[Element], newstate):
         """

--- a/edifice/base_components/base_components.py
+++ b/edifice/base_components/base_components.py
@@ -337,14 +337,6 @@ class QtWidgetElement(WidgetElement):
         The underlying QWidget, which may not exist if this Element has not rendered.
         """
 
-    # def _destroy_widgets(self):
-    #     """
-    #     Delete all children widgets recursively.
-    #     """
-    #     self.underlying = None # No guarantee that self.underlying exists
-    #     for child in self._widget_children:
-    #         child._destroy_widgets()
-
     def _set_size(self, width, height, size_from_font=None):
         self._height = height
         self._width = width
@@ -1831,18 +1823,9 @@ class View(_LinearView):
             # Then this is a fixed-position View
             assert old_child.underlying is not None
             old_child.underlying.setParent(None)
-            #TODO old_child.underlying.deleteLater()?
 
-
-    # def _destroy_widgets(self):
-    #     for i, child in reversed(list(enumerate(self._widget_children))):
-    #         self._delete_child(i, child)
-    #     self._widget_children = []
 
     def _soft_delete_child(self, i, old_child: QtWidgetElement):
-        # assert self.underlying_layout is not None
-        # self.underlying_layout.takeAt(i)
-
         if self.underlying_layout is not None:
             if self.underlying_layout.takeAt(i) is None:
                 logger.warning("_soft_delete_child takeAt failed " + str(i) + " " + str(self))
@@ -1890,7 +1873,11 @@ class View(_LinearView):
             self._initialize()
         assert self.underlying is not None
         commands = []
-        # TODO should we run the child commands after the View commands?
+        # Should we run the child commands after the View commands?
+        # No because children must be able to delete themselves before parent
+        # deletes them.
+        # https://doc.qt.io/qtforpython-6/PySide6/QtCore/QObject.html#detailed-description
+        # “The parent takes ownership of the object; i.e., it will automatically delete its children in its destructor.”
         commands.extend(self._recompute_children(children))
         commands.extend(self._qt_stateless_commands(children, newprops, newstate))
         return commands
@@ -1941,11 +1928,6 @@ class ScrollView(_LinearView):
                     logger.warning("_delete_child widget is None " + str(i) + " " + str(self))
                 else:
                     w.deleteLater()
-
-    # def _destroy_widgets(self):
-    #     for i, child in reversed(list(enumerate(self._widget_children))):
-    #         self._delete_child(i, child)
-    #     self._widget_children = []
 
     def _soft_delete_child(self, i, old_child: QtWidgetElement):
         if self.underlying_layout is None:

--- a/edifice/base_components/base_components.py
+++ b/edifice/base_components/base_components.py
@@ -1764,7 +1764,7 @@ class View(_LinearView):
     def _delete_child(self, i, old_child: QtWidgetElement):
         assert self.underlying_layout is not None
         child_node = self.underlying_layout.takeAt(i)
-        child_node.widget().deleteLater()
+        # child_node.widget().deleteLater()
         # old_child._destroy_widgets()
 
     def _destroy_widgets(self):
@@ -1855,7 +1855,7 @@ class ScrollView(_LinearView):
     def _delete_child(self, i, old_child):
         assert self.underlying_layout is not None
         child_node = self.underlying_layout.takeAt(i)
-        child_node.widget().deleteLater()
+        # child_node.widget().deleteLater()
         # old_child._destroy_widgets()
 
     def _destroy_widgets(self):

--- a/edifice/base_components/base_components.py
+++ b/edifice/base_components/base_components.py
@@ -1765,7 +1765,7 @@ class View(_LinearView):
         assert self.underlying_layout is not None
         child_node = self.underlying_layout.takeAt(i)
         child_node.widget().deleteLater()
-        old_child._destroy_widgets()
+        # old_child._destroy_widgets()
 
     def _destroy_widgets(self):
         for i, child in reversed(list(enumerate(self._widget_children))):
@@ -1856,7 +1856,7 @@ class ScrollView(_LinearView):
         assert self.underlying_layout is not None
         child_node = self.underlying_layout.takeAt(i)
         child_node.widget().deleteLater()
-        old_child._destroy_widgets()
+        # old_child._destroy_widgets()
 
     def _destroy_widgets(self):
         for i, child in reversed(list(enumerate(self._widget_children))):

--- a/edifice/base_components/base_components.py
+++ b/edifice/base_components/base_components.py
@@ -1751,6 +1751,9 @@ class View(_LinearView):
                 # very rapid updates to the UI.
                 if child_node.widget():
                     child_node.widget().deleteLater() # setParent(self._garbage_collector)
+            else:
+                logger.error(old_child.__class__.__name__ +
+                    " was not deleted because View QLayoutItem at " + str(i) + " was None")
         else:
             assert old_child.underlying is not None
             old_child.underlying.setParent(None)

--- a/edifice/base_components/flow_view.py
+++ b/edifice/base_components/flow_view.py
@@ -148,26 +148,26 @@ class FlowView(_LinearView):
         self.underlying = None
 
     def _delete_child(self, i, old_child):
-        if self.underlying_layout is not None: # TODO this is never true
-            child_node = self.underlying_layout.takeAt(i)
-            if child_node is not None and child_node.widget():
-                child_node.widget().deleteLater()
-        else:
-            old_child.underlying.setParent(None)
-        old_child._destroy_widgets()
+        # if self.underlying_layout is not None: # TODO this is never true
+        child_node = self.underlying_layout.takeAt(i)
+        #     if child_node is not None and child_node.widget():
+        #         child_node.widget().deleteLater()
+        # else:
+        #     old_child.underlying.setParent(None)
+        # old_child._destroy_widgets()
 
     def _soft_delete_child(self, i, old_child):
         # TODO This function is unreferenced
-        if self.underlying_layout is not None:
-            self.underlying_layout.takeAt(i)
-        else:
-            old_child.underlying.setParent(None)
+        # if self.underlying_layout is not None:
+        self.underlying_layout.takeAt(i)
+        # else:
+        #     old_child.underlying.setParent(None)
 
     def _add_child(self, i, child_component):
-        if self.underlying_layout is not None:
-            self.underlying_layout.insertWidget(i, child_component)
-        else:
-            child_component.setParent(self.underlying)
+        # if self.underlying_layout is not None:
+        self.underlying_layout.insertWidget(i, child_component)
+        # else:
+        #     child_component.setParent(self.underlying)
 
     def _initialize(self):
         self.underlying = QWidget()

--- a/edifice/base_components/flow_view.py
+++ b/edifice/base_components/flow_view.py
@@ -150,22 +150,7 @@ class FlowView(_LinearView):
         super().__init__(**kwargs)
         self.underlying = None
 
-    # def _delete_child(self, i, old_child):
-    #     # if self.underlying_layout is not None: # TODO this is never true
-    #     child_node = self.underlying_layout.takeAt(i)
-    #     #     if child_node is not None and child_node.widget():
-    #     #         child_node.widget().deleteLater()
-    #     # else:
-    #     #     old_child.underlying.setParent(None)
-    #     # old_child._destroy_widgets()
-    #     assert child_node is not None
-    #     child_node.widget().setParent(None)
-
     def _delete_child(self, i, old_child: QtWidgetElement):
-        # https://doc.qt.io/qtforpython-6/PySide6/QtCore/QObject.html#detailed-description
-        # “The parent takes ownership of the object; i.e., it will automatically delete its children in its destructor.”
-        # I think that sometimes when we try to delete a widget, it has already
-        # been deleted by its parent. So we can't just fail if the delete fails.
         if self.underlying_layout is None:
             logger.warning("_delete_child No underlying_layout " + str(self))
         else:
@@ -177,12 +162,6 @@ class FlowView(_LinearView):
                 else:
                     w.deleteLater()
 
-    # def _soft_delete_child(self, i, old_child):
-    #     # TODO This function is unreferenced
-    #     # if self.underlying_layout is not None:
-    #     self.underlying_layout.takeAt(i)
-    #     # else:
-    #     #     old_child.underlying.setParent(None)
     def _soft_delete_child(self, i, old_child: QtWidgetElement):
         if self.underlying_layout is None:
             logger.warning("_soft_delete_child No underlying_layout " + str(self))
@@ -192,10 +171,7 @@ class FlowView(_LinearView):
 
 
     def _add_child(self, i, child_component):
-        # if self.underlying_layout is not None:
         self.underlying_layout.insertWidget(i, child_component)
-        # else:
-        #     child_component.setParent(self.underlying)
 
     def _initialize(self):
         self.underlying = QWidget()

--- a/edifice/base_components/flow_view.py
+++ b/edifice/base_components/flow_view.py
@@ -8,6 +8,8 @@
 
 from ..qt import QT_VERSION
 import typing
+import logging
+
 if typing.TYPE_CHECKING:
     from PySide6.QtCore import QMargins, QPoint, QRect, QSize, Qt
     from PySide6.QtWidgets import QLayout, QLayoutItem, QSizePolicy, QWidget
@@ -19,8 +21,9 @@ else:
         from PySide6.QtCore import QMargins, QPoint, QRect, QSize, Qt
         from PySide6.QtWidgets import QLayout, QLayoutItem, QSizePolicy, QWidget
 
-from .base_components import _LinearView
+from .base_components import _LinearView, QtWidgetElement
 
+logger = logging.getLogger("Edifice")
 
 class FlowLayout(QLayout):
     def __init__(self, parent=None):
@@ -147,21 +150,46 @@ class FlowView(_LinearView):
         super().__init__(**kwargs)
         self.underlying = None
 
-    def _delete_child(self, i, old_child):
-        # if self.underlying_layout is not None: # TODO this is never true
-        child_node = self.underlying_layout.takeAt(i)
-        #     if child_node is not None and child_node.widget():
-        #         child_node.widget().deleteLater()
-        # else:
-        #     old_child.underlying.setParent(None)
-        # old_child._destroy_widgets()
+    # def _delete_child(self, i, old_child):
+    #     # if self.underlying_layout is not None: # TODO this is never true
+    #     child_node = self.underlying_layout.takeAt(i)
+    #     #     if child_node is not None and child_node.widget():
+    #     #         child_node.widget().deleteLater()
+    #     # else:
+    #     #     old_child.underlying.setParent(None)
+    #     # old_child._destroy_widgets()
+    #     assert child_node is not None
+    #     child_node.widget().setParent(None)
 
-    def _soft_delete_child(self, i, old_child):
-        # TODO This function is unreferenced
-        # if self.underlying_layout is not None:
-        self.underlying_layout.takeAt(i)
-        # else:
-        #     old_child.underlying.setParent(None)
+    def _delete_child(self, i, old_child: QtWidgetElement):
+        # https://doc.qt.io/qtforpython-6/PySide6/QtCore/QObject.html#detailed-description
+        # “The parent takes ownership of the object; i.e., it will automatically delete its children in its destructor.”
+        # I think that sometimes when we try to delete a widget, it has already
+        # been deleted by its parent. So we can't just fail if the delete fails.
+        if self.underlying_layout is None:
+            logger.warning("_delete_child No underlying_layout " + str(self))
+        else:
+            if (child_node := self.underlying_layout.takeAt(i)) is None:
+                logger.warning("_delete_child takeAt failed " + str(i) + " " + str(self))
+            else:
+                if (w := child_node.widget()) is None:
+                    logger.warning("_delete_child widget is None " + str(i) + " " + str(self))
+                else:
+                    w.deleteLater()
+
+    # def _soft_delete_child(self, i, old_child):
+    #     # TODO This function is unreferenced
+    #     # if self.underlying_layout is not None:
+    #     self.underlying_layout.takeAt(i)
+    #     # else:
+    #     #     old_child.underlying.setParent(None)
+    def _soft_delete_child(self, i, old_child: QtWidgetElement):
+        if self.underlying_layout is None:
+            logger.warning("_soft_delete_child No underlying_layout " + str(self))
+        else:
+            if self.underlying_layout.takeAt(i) is None:
+                logger.warning("_soft_delete_child takeAt failed " + str(i) + " " + str(self))
+
 
     def _add_child(self, i, child_component):
         # if self.underlying_layout is not None:

--- a/edifice/base_components/table_grid_view.py
+++ b/edifice/base_components/table_grid_view.py
@@ -1,6 +1,9 @@
 from typing import TYPE_CHECKING
 from typing_extensions import Self
 import typing as tp
+import logging
+
+logger = logging.getLogger("Edifice")
 
 from ..qt import QT_VERSION
 if QT_VERSION == "PyQt6" and not TYPE_CHECKING:
@@ -196,12 +199,17 @@ class TableGridView(QtWidgetElement):
             self.underlying_layout.setColumnMinimumWidth(column, self._column_minwidth[column])
 
     def _delete_child(self, child_component: QtWidgetElement, row:int, column:int):
-        layoutitem = self.underlying_layout.itemAtPosition(row, column)
-        assert layoutitem is not None
-        widget = layoutitem.widget()
-        assert widget is not None
-        # widget.deleteLater()
-        self.underlying_layout.removeItem(layoutitem)
+        if self.underlying_layout is None:
+            logger.warning("_delete_child No underlying_layout " + str(self))
+        else:
+            if (layoutitem := self.underlying_layout.itemAtPosition(row, column)) is None:
+                logger.warning("_delete_child itemAtPosition failed " + str((row,column)) + " " + str(self))
+            else:
+                self.underlying_layout.removeItem(layoutitem)
+                if (w := layoutitem.widget()) is None:
+                    logger.warning("_delete_child widget is None " + str((row,column)) + " " + str(self))
+                else:
+                    w.deleteLater()
 
     def _qt_update_commands(
         self,

--- a/edifice/base_components/table_grid_view.py
+++ b/edifice/base_components/table_grid_view.py
@@ -200,7 +200,7 @@ class TableGridView(QtWidgetElement):
         assert layoutitem is not None
         widget = layoutitem.widget()
         assert widget is not None
-        widget.deleteLater()
+        # widget.deleteLater()
         self.underlying_layout.removeItem(layoutitem)
 
     def _qt_update_commands(

--- a/edifice/base_components/table_grid_view.py
+++ b/edifice/base_components/table_grid_view.py
@@ -240,12 +240,6 @@ class TableGridView(QtWidgetElement):
         children_of_rows: list[_WidgetTree] = list()
         for c in children:
             children_of_rows.extend(c.children)
-        # children_of_rows: list[QtWidgetElement] = list()
-        # for c in children:
-        #     # children_of_rows.extend([comp.component for comp in c.children])
-        #     for comp in c.children:
-        #         assert isinstance(comp.component, QtWidgetElement)
-        #         children_of_rows.append(comp.component)
 
         newchildren = _childdict(children_of_rows)
 

--- a/edifice/base_components/table_grid_view.py
+++ b/edifice/base_components/table_grid_view.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 from typing_extensions import Self
+import typing as tp
 
 from ..qt import QT_VERSION
 if QT_VERSION == "PyQt6" and not TYPE_CHECKING:
@@ -9,6 +10,9 @@ else:
 
 from .._component import Element, BaseElement, _CommandType
 from .base_components import QtWidgetElement
+
+# TODO instead of attaching these attributes to the elements, the
+# TableGridView could have a dict of dict[Element, tuple[row,column,key]]
 
 def _get_tablerowcolumn(c:Element) -> tuple[int,int]:
     """
@@ -145,7 +149,7 @@ class TableGridView(QtWidgetElement):
         })
         self._register_props(kwargs)
         self.underlying = None
-        self._widget_children_dict = {}
+        self._widget_children_dict : dict[tuple[int,int,str], QtWidgetElement] = {}
         """Like _LinearView._widget_children"""
         self._row_stretch = row_stretch
         self._column_stretch = column_stretch
@@ -178,8 +182,9 @@ class TableGridView(QtWidgetElement):
         while self.underlying_layout.takeAt(0) is not None:
             pass
 
-    def _add_child(self, child_component, row:int, column:int):
+    def _add_child(self, child_component: QtWidgetElement, row:int, column:int):
         # https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QGridLayout.html#PySide6.QtWidgets.PySide6.QtWidgets.QGridLayout.addWidget
+        assert type(child_component.underlying) == QWidget
         self.underlying_layout.addWidget(child_component.underlying, row, column)
         if len(self._row_stretch) > row:
             self.underlying_layout.setRowStretch(row, self._row_stretch[row])
@@ -190,7 +195,7 @@ class TableGridView(QtWidgetElement):
         if len(self._column_minwidth) > column:
             self.underlying_layout.setColumnMinimumWidth(column, self._column_minwidth[column])
 
-    def _delete_child(self, child_component, row:int, column:int):
+    def _delete_child(self, child_component: QtWidgetElement, row:int, column:int):
         layoutitem = self.underlying_layout.itemAtPosition(row, column)
         assert layoutitem is not None
         widget = layoutitem.widget()

--- a/edifice/base_components/table_grid_view.py
+++ b/edifice/base_components/table_grid_view.py
@@ -184,7 +184,7 @@ class TableGridView(QtWidgetElement):
 
     def _add_child(self, child_component: QtWidgetElement, row:int, column:int):
         # https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QGridLayout.html#PySide6.QtWidgets.PySide6.QtWidgets.QGridLayout.addWidget
-        assert type(child_component.underlying) == QWidget
+        assert child_component.underlying is not None
         self.underlying_layout.addWidget(child_component.underlying, row, column)
         if len(self._row_stretch) > row:
             self.underlying_layout.setRowStretch(row, self._row_stretch[row])

--- a/edifice/engine.py
+++ b/edifice/engine.py
@@ -344,6 +344,9 @@ class _HookAsync:
     The dependencies of use_async().
     """
 
+def elements_match(a: Element, b: Element) -> bool:
+    return ((a.__class__.__name__ == b.__class__.__name__)
+        and (getattr(a, "_key", None) == getattr(b, "_key", None)))
 
 class RenderEngine(object):
     """
@@ -547,58 +550,65 @@ class RenderEngine(object):
         render_context.mark_props_change(component, newprops)
         render_context.mark_qt_rerender(component, False)
         return self._widget_tree[component]
+        # TODO return None?
 
-    def _get_child_using_key(self, d, key, newchild, render_context: _RenderContext):
-        if key not in d or d[key].__class__ != newchild.__class__:
-            return newchild
-        self._update_old_component(d[key], newchild, render_context)
-        return d[key]
-
-    def _attach_keys(self, component: Element, render_context: _RenderContext):
-        for i, child in enumerate(component.children):
-            if not hasattr(child, "_key"):
-                # logger.warning("Setting child key of %s to: %s", component, "KEY" + str(i))
-                render_context.set(child, "_key", "KEY" + str(i))
-
-    def _recycle_children(self, component: Element, render_context: _RenderContext):
+    def _recycle_children(self, component: BaseElement, render_context: _RenderContext):
+        # Children diffing and reconciliation
+        #
         # Returns children, which contains all the future children of the component:
         # a mixture of old components (if they can be updated) and new ones
 
-        # Determine list of former children
-        old_children = self._component_tree[component]
+        children_old_bykey : dict[str, Element] = dict()
+        children_new_bykey : dict[str, Element] = dict()
 
-        # TODO: match on if old_children is a single Element or not
-        if len(component.children) == 1 and len(old_children) == 1:
-            # If both former and current child lists are length 1 then
-            # compare class and _key. If they match, then update the old child.
-            if (component.children[0].__class__ == old_children[0].__class__
-                    and getattr(component.children[0], "_key", None) == getattr(old_children[0], "_key", None)):
-                self._update_old_component(old_children[0], component.children[0], render_context)
-                children = [old_children[0]]
-            else:
-                children = [component.children[0]]
-        else:
-            if len(component.children) <= 1:
-                self._attach_keys(component, render_context)
-            if len(component.children) != len(set(child._key for child in component.children)):
-                raise ValueError("Duplicate keys found in %s" % component)
-            if len(old_children) == 1:
-                if not hasattr(old_children[0], "_key"):
-                    render_context.set(old_children[0], "_key", "KEY0")
-            key_to_old_child = {child._key: child for child in old_children}
-            children = [self._get_child_using_key(key_to_old_child, new_child._key, new_child, render_context)
-                        for new_child in component.children]
+        children_old_ = self._component_tree[component]
+        assert isinstance(children_old_, list)
 
-        # Delete all old children that are not used
-        children_set = set(children)
-        for old_child in old_children:
-            if old_child not in children_set:
-                render_context.enqueued_deletions.append(old_child)
-        return children
+		# We will mutate children_old to reuse and remove old elements if we can match them.
+        # Ordering of children_old must be preserved for reverse deletion.
+        children_old: list[Element] = children_old_[:]
+        for child_old in children_old:
+            if hasattr(child_old, "_key"):
+                children_old_bykey[child_old._key] = child_old
+
+		# We will mutate children_new to replace them with old elements if we can match them.
+        children_new: list[Element] = component.children[:]
+        for child_new in children_new:
+            if hasattr(child_new, "_key"):
+                if children_new_bykey.get(child_new._key, None) is not None:
+                    raise ValueError("Duplicate keys found in %s" % component)
+                children_new_bykey[child_new._key] = child_new
+
+        # We will not try to intelligently handle the situation where
+        # an unkeyed element is added or removed.
+        # If the elements are unkeyed then try to match them pairwise.
+        i_old = 0
+        i_new = 0
+        while i_new < len(children_new):
+            child_new = children_new[i_new]
+            if (key := getattr(child_new, "_key", None)) is not None:
+                if ((child_old_bykey := children_old_bykey.get(key, None)) is not None
+                    and elements_match(child_old_bykey, child_new)):
+                    # then we have a match for reuse
+                    self._update_old_component(child_old_bykey, child_new, render_context)
+                    children_new[i_new] = child_old_bykey
+                    children_old.remove(child_old_bykey)
+            elif i_old < len(children_old):
+                child_old = children_old[i_old]
+                if elements_match(child_old, child_new):
+                    # then we have a match for reuse
+                    self._update_old_component(child_old, child_new, render_context)
+                    children_new[i_new] = child_old
+                    del children_old[i_old]
+                else:
+                    # leave this old element to be deleted
+                    i_old += 1
+            i_new += 1
+
+        render_context.enqueued_deletions.extend(children_old)
+        return children_new
 
     def _render_base_component(self, component: BaseElement, render_context: _RenderContext) -> _WidgetTree:
-        if len(component.children) > 1:
-            self._attach_keys(component, render_context)
         if component not in self._component_tree:
             # New component, simply render everything
             render_context.component_tree[component] = list(component.children)
@@ -608,7 +618,7 @@ class RenderEngine(object):
             render_context.schedule_callback(component._did_mount)
             return render_context.widget_tree[component]
 
-        # Figure out which children are pre-existing
+        # Figure out which children can be re-used
         children = self._recycle_children(component, render_context)
 
         # TODO: What if children key order changed??

--- a/edifice/engine.py
+++ b/edifice/engine.py
@@ -307,7 +307,12 @@ class RenderResult(object):
         This is the phase of the render when the commands run.
         """
         for command in self.commands:
-            command.fn(*command.args, **command.kwargs)
+            try:
+                command.fn(*command.args, **command.kwargs)
+            except Exception as ex:
+                logger.exception("Exception while running command:\n"
+                                 + str(command) + "\n"
+                                 + str(ex) + "\n")
         self.render_context.run_callbacks()
 
 @dataclass

--- a/edifice/engine.py
+++ b/edifice/engine.py
@@ -387,13 +387,6 @@ class RenderEngine(object):
                     self._delete_component(sub_comp, recursive)
             # Node deletion
 
-        assert component._edifice_internal_references is not None
-        for ref in component._edifice_internal_references:
-            ref._value = None
-        component._will_unmount()
-        del self._component_tree[component]
-        del self._widget_tree[component]
-
         # Clean up hook state for the component
         if component in self._hook_state:
             for hook in self._hook_state[component]:
@@ -423,6 +416,16 @@ class RenderEngine(object):
                 del hook.dependencies
                 del hook
             del self._hook_async[component]
+
+        # Clean up component references
+        # Do this after use_effect cleanup, so that the cleanup function
+        # can still access the component References.
+        assert component._edifice_internal_references is not None
+        for ref in component._edifice_internal_references:
+            ref._value = None
+        component._will_unmount()
+        del self._component_tree[component]
+        del self._widget_tree[component]
 
     def _refresh_by_class(self, classes) -> RenderResult:
         # This refresh is done only for a hot reload. It refreshes all

--- a/edifice/logger.py
+++ b/edifice/logger.py
@@ -46,5 +46,5 @@ handler = logging.StreamHandler()
 handler.setFormatter(ColoredFormatter(FORMAT, "%Y-%m-%d %H:%M:%S"))
 
 logger = logging.getLogger("Edifice")
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.FATAL)
 logger.addHandler(handler)

--- a/examples/test_children_from_state.py
+++ b/examples/test_children_from_state.py
@@ -1,0 +1,119 @@
+"""
+This is a test of rapidly changing the children of a View based on state.
+
+Seems to work fine.
+"""
+
+import logging
+import sys
+import os
+import typing as tp
+# We need this sys.path line for running this example, especially in VSCode debugger.
+sys.path.insert(0, os.path.join(sys.path[0], '..'))
+from edifice import App, Window, View, component, Slider, Label, use_state, use_effect, Image, Reference, use_ref, TableGridView
+
+from edifice.qt import QT_VERSION
+if QT_VERSION == "PyQt6" and not tp.TYPE_CHECKING:
+    from PyQt6.QtCore import Qt
+    from PyQt6 import QtWidgets
+else:
+    from PySide6.QtCore import Qt
+    from PySide6 import QtWidgets
+
+logger = logging.getLogger("Edifice")
+logger.setLevel(logging.INFO)
+
+# @component
+# def MyComponent(self):
+#     x, x_set = use_state(0)
+#
+#     with View(layout="column"):
+#         Slider(x, min_value=0, max_value=100, on_change=x_set)
+#         with View(layout="row"):
+#             for i in range(x):
+#                 Label(str(i)).set_key("X"+str(i))
+
+imgpath = os.path.join(os.path.dirname(__file__), "example_calculator.png")
+
+@component
+def MyComponent3(self):
+    x, x_set = use_state(0)
+    x_minus, x_minus_set = use_state(0)
+
+    vref: Reference = use_ref()
+    resize_trigger, resize_trigger_set = use_state(False)
+    def handle_resize(_event):
+        print("resize")
+        resize_trigger_set(lambda x: not x)
+    def initialize():
+        if vref:
+            view_element = vref()
+            assert type(view_element) == View
+            assert isinstance(view_element.underlying, QtWidgets.QWidget)
+            view_element.underlying.resizeEvent = handle_resize
+            def cleanup():
+                assert type(view_element) == View
+                assert isinstance(view_element.underlying, QtWidgets.QWidget)
+                view_element.underlying.resizeEvent = lambda _event: None
+            return cleanup
+        else:
+            return lambda:None
+    use_effect(initialize, [])
+
+    with View(layout="column"):
+        with TableGridView() as tgv:
+            with tgv.row():
+                Slider(x, min_value=0, max_value=100, on_change=x_set).set_key("row1")
+            with tgv.row():
+                Slider(x_minus, min_value=0, max_value=100, on_change=x_minus_set).set_key("row2")
+            with tgv.row():
+                with View(layout="row").register_ref(vref).set_key("row3"):
+                    for i in range(x_minus, x):
+                    # for i in range(x):
+                    #     if i < x_minus or i > x_minus + 10 or divmod(i, 2)[1] == 0:
+                        with View(layout="column", style={"align":"center"}).set_key("view"+str(i)):
+                            Label(str(i))# .set_key("X"+str(i))
+                            Image(
+                                src=imgpath,
+                                aspect_ratio_mode=Qt.AspectRatioMode.KeepAspectRatio,
+                                style={
+                                    "width":15,
+                                    "height": 15,
+                                }
+                            )# .set_key("img"+str(i))
+
+@component
+def MyComponent(self):
+    x, x_set = use_state(0)
+
+    with View(layout="column"):
+        Slider(x, min_value=0, max_value=100, on_change=x_set)
+        InnerComponent(x)
+
+@component
+def InnerComponent(self, x:int):
+    y, y_set = use_state(x)
+
+    def y_setter():
+        y_set(x)
+        return lambda:None
+
+    use_effect(y_setter, x)
+
+    with View(layout="row"):
+        for i in range(y):
+            ItemComponent(i).set_key("X"+str(i))
+
+@component
+def ItemComponent(self, i:int):
+    with View():
+        Label(str(i))
+
+
+@component
+def Main(self):
+    with Window():
+        MyComponent3()
+
+if __name__ == "__main__":
+    App(Main()).start()

--- a/examples/use_effect_async2.py
+++ b/examples/use_effect_async2.py
@@ -1,0 +1,29 @@
+#
+# python examples/use_effect_async1.py
+#
+
+import asyncio as asyncio
+import sys, os
+# We need this sys.path line for running this example, especially in VSCode debugger.
+sys.path.insert(0, os.path.join(sys.path[0], '..'))
+from edifice import App, Window, View, Label, Button, component, TextInput
+from edifice.hooks import use_state, use_async
+
+@component
+def MainComp(self):
+    x, x_set = use_state("")
+    async def effect():
+        await asyncio.sleep(0.5)
+        print(x)
+    use_async(effect, x)
+    with Window():
+        with View():
+            TextInput(
+                text=x,
+                on_change=x_set
+            )
+
+if __name__ == "__main__":
+    my_app = App(MainComp())
+    with my_app.start_loop() as loop:
+        loop.run_forever()


### PR DESCRIPTION
Rewrite both of the diffing and reconciliation functions:

1. `_recompute_children()` now it correctly handles the case that a child is moved to a different position. To do this we finished the `_soft_delete_child()` work which was started by David Deng.
2. `_recycle_children()` now it does not add spurious `"KEY1"`, `"KEY2"`, `"Key3"` keys to all of the children.

Change the `App._defer_rerender()` function so that it takes no `Element` arguments, and therefore will not mistakenly capture references to `Element`s which were deleted.

Restore the `logging`.