### PR TITLE
PyQtPlot: hide buttons to actually disable mouse

### DIFF
--- a/edifice/extra/pyqtgraph_plot.py
+++ b/edifice/extra/pyqtgraph_plot.py
@@ -69,6 +69,7 @@ class PyQtPlot(QtWidgetElement):
             # Disable mouse interaction
             # https://pyqtgraph.readthedocs.io/en/latest/api_reference/graphicsItems/viewbox.html#pyqtgraph.ViewBox.setMouseEnabled
             self.underlying.setMouseEnabled(x=False, y=False)
+            self.underlying.hideButtons()
 
         commands = super()._qt_update_commands_super(children, newprops, newstate, self.underlying)
 


### PR DESCRIPTION
For some reason, `PlotView.setMouseEnabled(False,False)` is not enough to actually disable mouse interaction, you have to aslo hide the buttons through which the zooming is controlled.