### PR TITLE
Flag render engine as stopped before deleting it

### DIFF
--- a/edifice/app.py
+++ b/edifice/app.py
@@ -391,7 +391,7 @@ class App(object):
         async def app_run():
             await self._app_close_event.wait()
             engine = self._render_engine
-            engine._stop()
+            engine.is_stopped = True
             engine._delete_component(self._root, True)
             # At this time, all use_async hook tasks have been cancel()ed.
             # Wait until all the cancelled tasks are done(), then exit.

--- a/edifice/app.py
+++ b/edifice/app.py
@@ -390,10 +390,19 @@ class App(object):
 
         async def app_run():
             await self._app_close_event.wait()
-            self._render_engine._delete_component(self._root, True)
+            engine = self._render_engine
+            engine._delete_component(self._root, True)
             # At this time, all use_async hook tasks have been cancel()ed.
             # Wait until all the cancelled tasks are done(), then exit.
-            while len(self._render_engine._hook_async) > 0:
+            while len(engine._hook_async) > 0:
+                # Remove finished components from engine async hooks
+                to_delete = [
+                    component
+                    for component in engine._hook_async
+                    if engine.is_hook_async_done(component)
+                ]
+                for component in to_delete:
+                    del engine._hook_async[component]
                 await asyncio.sleep(0.0)
 
         loop.run_until_complete(app_run())

--- a/edifice/app.py
+++ b/edifice/app.py
@@ -391,6 +391,7 @@ class App(object):
         async def app_run():
             await self._app_close_event.wait()
             engine = self._render_engine
+            engine._stop()
             engine._delete_component(self._root, True)
             # At this time, all use_async hook tasks have been cancel()ed.
             # Wait until all the cancelled tasks are done(), then exit.

--- a/edifice/engine.py
+++ b/edifice/engine.py
@@ -299,7 +299,7 @@ class RenderEngine(object):
     __slots__ = (
         "_component_tree", "_widget_tree", "_root", "_app",
         "_hook_state", "_hook_state_setted",
-        "_hook_effect", "_hook_async", "_is_stopped",
+        "_hook_effect", "_hook_async", "is_stopped",
     )
     def __init__(self, root:Element, app=None):
         self._component_tree : dict[Element, list[Element]] = {}
@@ -330,7 +330,7 @@ class RenderEngine(object):
         """
         The per-element hooks for use_async().
         """
-        self._is_stopped: bool = False
+        self.is_stopped: bool = False
         """
         Flag determining if the render engine has been stopped.
         """
@@ -404,7 +404,7 @@ class RenderEngine(object):
         # elements which were defined in a module which was changed
         # on the filesystem.
 
-        if self._is_stopped:
+        if self.is_stopped:
             return
 
         # Algorithm:
@@ -714,7 +714,7 @@ class RenderEngine(object):
         Recursively generate the update commands for the widget tree.
         """
         commands : list[_CommandType] = []
-        if self._is_stopped:
+        if self.is_stopped:
             return commands
 
         children = _get_widget_children(render_context.widget_tree, element)
@@ -734,7 +734,7 @@ class RenderEngine(object):
         return commands
 
     def _request_rerender(self, components: list[Element]) -> RenderResult:
-        if self._is_stopped:
+        if self.is_stopped:
             return RenderResult([])
 
         components_ = components[:]
@@ -818,6 +818,3 @@ class RenderEngine(object):
 
         # We return all the commands but that's only needed for testing.
         return RenderResult(all_commands)
-
-    def _stop(self) -> None:
-        self._is_stopped = True


### PR DESCRIPTION
This avoids running new renders once that the render engine has been set for deletion, avoiding also to re-schedule new async calls (that may block forever line 398 in `app.py`).