### PR TITLE
Allow sliders to ignore the mouse wheel scrolling

### DIFF
--- a/edifice/base_components/base_components.py
+++ b/edifice/base_components/base_components.py
@@ -872,6 +872,8 @@ class Slider(QtWidgetElement):
         max_value: int = 100,
         orientation: QtCore.Qt.Orientation = QtCore.Qt.Orientation.Horizontal,
         on_change: tp.Callable[[int], None | tp.Awaitable[None]] | None = None,
+        *,
+        ignore_scrolling: bool = True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -881,6 +883,7 @@ class Slider(QtWidgetElement):
             "max_value": max_value,
             "orientation": orientation,
             "on_change": on_change,
+            "ignore_scrolling": ignore_scrolling,
         })
         self._register_props(kwargs)
         self._connected = False
@@ -897,6 +900,8 @@ class Slider(QtWidgetElement):
 
         self.underlying.setObjectName(str(id(self)))
         self.underlying.valueChanged.connect(self._on_change_handle)
+        if "ignore_scrolling" in self.props and self.props.ignore_scrolling:
+            self.underlying.wheelEvent = lambda e: e.ignore() 
 
     def _on_change_handle(self, position:int) -> None:
         if self._on_change is not None:


### PR DESCRIPTION
This PR adds an option argument to the `Slider` to choose if the mouse scrolling action should be ignored or not.

I opted for an option because I can see the adjust slider on scroll to be helpful for accessibility but at the same time it can be inconvenient when embedding a slider inside a `ScrollView`, for example.