### PR TITLE
Make _CommandType non-private

### DIFF
--- a/edifice/base_components/base_components.py
+++ b/edifice/base_components/base_components.py
@@ -6,7 +6,7 @@ import typing as tp
 from ..engine import (
     _WidgetTree,
     _get_widget_children,
-    _CommandType,
+    CommandType,
     PropsDict,
     Element,
     QtWidgetElement,
@@ -108,8 +108,8 @@ class GroupBox(QtWidgetElement):
         child_underlying = children[0].underlying
         assert child_underlying is not None
         widget = tp.cast(QtWidgets.QGroupBox, self.underlying)
-        commands.append(_CommandType(child_underlying.setParent, self.underlying))
-        commands.append(_CommandType(widget.setTitle, self.props.title))
+        commands.append(CommandType(child_underlying.setParent, self.underlying))
+        commands.append(CommandType(widget.setTitle, self.props.title))
         return commands
 
 
@@ -207,7 +207,7 @@ class Icon(QtWidgetElement):
             or "rotation" in newprops
         ):
             commands.append(
-                _CommandType(self._render_image, icon_path, self.props.size, self.props.color, self.props.rotation)
+                CommandType(self._render_image, icon_path, self.props.size, self.props.color, self.props.rotation)
             )
 
         return commands
@@ -257,7 +257,7 @@ class Button(QtWidgetElement):
         widget = tp.cast(QtWidgets.QPushButton, self.underlying)
         for prop in newprops:
             if prop == "title":
-                commands.append(_CommandType(widget.setText, str(newprops.title)))
+                commands.append(CommandType(widget.setText, str(newprops.title)))
 
         return commands
 
@@ -350,7 +350,7 @@ class IconButton(Button):
             or "rotation" in newprops
         ):
             commands.append(
-                _CommandType(render_image, icon_path, self.props.size, self.props.color, self.props.rotation)
+                CommandType(render_image, icon_path, self.props.size, self.props.color, self.props.rotation)
             )
 
         return commands
@@ -421,11 +421,11 @@ class Label(QtWidgetElement):
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying, None)
         for prop in newprops:
             if prop == "text":
-                commands.append(_CommandType(widget.setText, str(newprops[prop])))
+                commands.append(CommandType(widget.setText, str(newprops[prop])))
             elif prop == "word_wrap":
-                commands.append(_CommandType(widget.setWordWrap, self.props.word_wrap))
+                commands.append(CommandType(widget.setWordWrap, self.props.word_wrap))
             elif prop == "link_open":
-                commands.append(_CommandType(widget.setOpenExternalLinks, self.props.link_open))
+                commands.append(CommandType(widget.setOpenExternalLinks, self.props.link_open))
             elif prop == "selectable" or prop == "editable":
                 interaction_flags = 0
                 change_cursor = False
@@ -444,9 +444,9 @@ class Label(QtWidgetElement):
                     else:
                         interaction_flags = QtCore.Qt.TextInteractionFlag.TextEditable
                 if change_cursor and self.props.cursor is None:
-                    commands.append(_CommandType(widget.setCursor, _CURSORS["text"]))
+                    commands.append(CommandType(widget.setCursor, _CURSORS["text"]))
                 if interaction_flags:
-                    commands.append(_CommandType(widget.setTextInteractionFlags, interaction_flags))
+                    commands.append(CommandType(widget.setTextInteractionFlags, interaction_flags))
         return commands
 
 
@@ -487,7 +487,7 @@ class ImageSvg(QtWidgetElement):
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying, None)
         for prop in newprops:
             if prop == "src":
-                commands.append(_CommandType(widget.load, self.props.src))
+                commands.append(CommandType(widget.load, self.props.src))
         return commands
 
 
@@ -613,12 +613,12 @@ class TextInput(QtWidgetElement):
 
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying)
         if "text" in newprops:
-            commands.append(_CommandType(widget.setText, str(newprops.text)))
+            commands.append(CommandType(widget.setText, str(newprops.text)))
             # This setCursorPosition is needed because otherwise the cursor will
             # jump to the end of the text after the setText.
-            commands.append(_CommandType(widget.setCursorPosition, widget.cursorPosition()))
+            commands.append(CommandType(widget.setCursorPosition, widget.cursorPosition()))
         if "placeholder_text" in newprops:
-            commands.append(_CommandType(widget.setPlaceholderText, newprops.placeholder_text))
+            commands.append(CommandType(widget.setPlaceholderText, newprops.placeholder_text))
         return commands
 
 
@@ -723,20 +723,20 @@ class Dropdown(QtWidgetElement):
         widget = tp.cast(QtWidgets.QComboBox, self.underlying)
 
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying)
-        commands.append(_CommandType(widget.setEditable, self.props.editable))
+        commands.append(CommandType(widget.setEditable, self.props.editable))
         if "options" in newprops:
             commands.extend(
                 [
-                    _CommandType(widget.clear),
-                    _CommandType(widget.addItems, newprops.options),
+                    CommandType(widget.clear),
+                    CommandType(widget.addItems, newprops.options),
                 ]
             )
         if "text" in newprops:
-            commands.append(_CommandType(self._set_edit_text, newprops.text))
+            commands.append(CommandType(self._set_edit_text, newprops.text))
         if "selection" in newprops:
-            commands.append(_CommandType(self._set_current_text, newprops.selection))
+            commands.append(CommandType(self._set_current_text, newprops.selection))
         # elif prop == "completer":
-        #     commands.append(_CommandType(self._set_completer, newprops[prop]))
+        #     commands.append(CommandType(self._set_completer, newprops[prop]))
         return commands
 
 
@@ -812,9 +812,9 @@ class RadioButton(QtWidgetElement):
 
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying)
         if "checked" in newprops:
-            commands.append(_CommandType(self._set_checked, newprops.checked))
+            commands.append(CommandType(self._set_checked, newprops.checked))
         if "text" in newprops:
-            commands.append(_CommandType(widget.setText, str(newprops.text)))
+            commands.append(CommandType(widget.setText, str(newprops.text)))
         return commands
 
 
@@ -893,9 +893,9 @@ class CheckBox(QtWidgetElement):
 
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying)
         if "text" in newprops:
-            commands.append(_CommandType(widget.setText, str(newprops.text)))
+            commands.append(CommandType(widget.setText, str(newprops.text)))
         if "checked" in newprops:
-            commands.append(_CommandType(self._set_checked, newprops.checked))
+            commands.append(CommandType(self._set_checked, newprops.checked))
         return commands
 
 
@@ -1001,13 +1001,13 @@ class Slider(QtWidgetElement):
 
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying)
         if "min_value" in newprops:
-            commands.append(_CommandType(widget.setMinimum, newprops.min_value))
+            commands.append(CommandType(widget.setMinimum, newprops.min_value))
         if "max_value" in newprops:
-            commands.append(_CommandType(widget.setMaximum, newprops.max_value))
+            commands.append(CommandType(widget.setMaximum, newprops.max_value))
         if "value" in newprops:
-            commands.append(_CommandType(self._set_value, newprops.value))
+            commands.append(CommandType(self._set_value, newprops.value))
         if "on_change" in newprops:
-            commands.append(_CommandType(self._set_on_change, newprops.on_change))
+            commands.append(CommandType(self._set_on_change, newprops.on_change))
         return commands
 
 
@@ -1028,7 +1028,7 @@ class _LinearView(QtWidgetElement):
 
         children_new = children
 
-        commands: list[_CommandType] = []
+        commands: list[CommandType] = []
 
         children_old_positioned_reverse: list[QtWidgetElement] = []
         # old children in the same position as new children.
@@ -1058,10 +1058,10 @@ class _LinearView(QtWidgetElement):
                     # old child is out of position
                     if child_old in children_new:
                         # child will be added back in later
-                        commands.append(_CommandType(self._soft_delete_child, i_old, child_old))
+                        commands.append(CommandType(self._soft_delete_child, i_old, child_old))
                     else:
                         # child will be deleted
-                        commands.append(_CommandType(self._delete_child, i_old, child_old))
+                        commands.append(CommandType(self._delete_child, i_old, child_old))
                 i_new += 1
 
             r = list(reversed(children_old_positioned_reverse))
@@ -1083,10 +1083,10 @@ class _LinearView(QtWidgetElement):
                     # old child is out of position
                     if child_old in children_new:
                         # child will be added back in later
-                        commands.append(_CommandType(self._soft_delete_child, i_old, child_old))
+                        commands.append(CommandType(self._soft_delete_child, i_old, child_old))
                     else:
                         # child will be deleted
-                        commands.append(_CommandType(self._delete_child, i_old, child_old))
+                        commands.append(CommandType(self._delete_child, i_old, child_old))
                 i_new -= 1
 
         # Now we have deleted all the old children that are not in the right position.
@@ -1098,7 +1098,7 @@ class _LinearView(QtWidgetElement):
             else:
                 assert isinstance(child_new, QtWidgetElement)
                 assert child_new.underlying is not None
-                commands.append(_CommandType(self._add_child, i, child_new.underlying))
+                commands.append(CommandType(self._add_child, i, child_new.underlying))
 
         # assert sanity check that we used all the old children.
         assert len(children_old_positioned_reverse) == 0
@@ -1315,20 +1315,20 @@ class Window(View):
             self.underlying.closeEvent = self._handle_close
             self.underlying.show()
 
-        commands: list[_CommandType] = super()._qt_update_commands(widget_trees, newprops)
+        commands: list[CommandType] = super()._qt_update_commands(widget_trees, newprops)
 
         if "title" in newprops:
-            commands.append(_CommandType(self.underlying.setWindowTitle, newprops.title))
+            commands.append(CommandType(self.underlying.setWindowTitle, newprops.title))
         if "on_close" in newprops:
-            commands.append(_CommandType(self._set_on_close, newprops.on_close))
+            commands.append(CommandType(self._set_on_close, newprops.on_close))
         if "icon" in newprops and newprops.icon:
             pixmap = _image_descriptor_to_pixmap(newprops.icon)
-            commands.append(_CommandType(self.underlying.setWindowIcon, QtGui.QIcon(pixmap)))
+            commands.append(CommandType(self.underlying.setWindowIcon, QtGui.QIcon(pixmap)))
         if "menu" in newprops and newprops.menu:
             if self._menu_bar is not None:
                 self._menu_bar.setParent(None)
             self._menu_bar = QtWidgets.QMenuBar()
-            commands.append(_CommandType(self._attach_menubar, self._menu_bar, newprops.menu))
+            commands.append(CommandType(self._attach_menubar, self._menu_bar, newprops.menu))
 
         return commands
 
@@ -1583,11 +1583,11 @@ class GridView(QtWidgetElement):
         else:
             code_to_child = {self.props.key_to_code[c._key]: c for c in children}
         grid_spec = [(code_to_child[cell[0]],) + cell[1:] for cell in grid_spec if cell[0] not in " _"]
-        commands: list[_CommandType] = []
+        commands: list[CommandType] = []
         if grid_spec != self._previously_rendered:
-            commands.append(_CommandType(self._clear))
+            commands.append(CommandType(self._clear))
             for child, y, x, dy, dx in grid_spec:
-                commands.append(_CommandType(self.underlying_layout.addWidget, child.underlying, y, x, dy, dx))
+                commands.append(CommandType(self.underlying_layout.addWidget, child.underlying, y, x, dy, dx))
             self._previously_rendered = grid_spec
         commands.extend(super()._qt_update_commands_super(widget_trees, newprops, self.underlying, None))
         return commands
@@ -1697,7 +1697,7 @@ class CustomWidget(QtWidgetElement):
         if self.underlying is None:
             self.underlying = self.create_widget()
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying, None)
-        commands.append(_CommandType(self.paint, self.underlying, newprops))
+        commands.append(CommandType(self.paint, self.underlying, newprops))
         return commands
 
 
@@ -1749,21 +1749,21 @@ class ExportList(QtWidgetElement):
 #
 #         for prop in newprops:
 #             if prop == "rows":
-#                 commands.append(_CommandType(widget.setRowCount, newprops[prop]))
+#                 commands.append(CommandType(widget.setRowCount, newprops[prop]))
 #             elif prop == "columns":
-#                 commands.append(_CommandType(widget.setColumnCount, newprops[prop]))
+#                 commands.append(CommandType(widget.setColumnCount, newprops[prop]))
 #             elif prop == "alternating_row_colors":
-#                 commands.append(_CommandType(widget.setAlternatingRowColors, newprops[prop]))
+#                 commands.append(CommandType(widget.setAlternatingRowColors, newprops[prop]))
 #             elif prop == "row_headers":
 #                 if newprops[prop] is not None:
-#                     commands.append(_CommandType(widget.setVerticalHeaderLabels, list(map(str, newprops[prop]))))
+#                     commands.append(CommandType(widget.setVerticalHeaderLabels, list(map(str, newprops[prop]))))
 #                 else:
-#                     commands.append(_CommandType(widget.setVerticalHeaderLabels, list(map(str, range(newprops.rows)))))
+#                     commands.append(CommandType(widget.setVerticalHeaderLabels, list(map(str, range(newprops.rows)))))
 #             elif prop == "column_headers":
 #                 if newprops[prop] is not None:
-#                     commands.append(_CommandType(widget.setHorizontalHeaderLabels, list(map(str, newprops[prop]))))
+#                     commands.append(CommandType(widget.setHorizontalHeaderLabels, list(map(str, newprops[prop]))))
 #                 else:
-#                     commands.append(_CommandType(widget.setHorizontalHeaderLabels, list(map(str, range(newprops.columns)))))
+#                     commands.append(CommandType(widget.setHorizontalHeaderLabels, list(map(str, range(newprops.columns)))))
 #
 #         new_children = set()
 #         for child in children:
@@ -1777,13 +1777,13 @@ class ExportList(QtWidgetElement):
 #             if old_child not in new_children:
 #                 for j, el in enumerate(old_child.children):
 #                     if el:
-#                         commands.append(_CommandType(widget.setCellWidget, i, j, QtWidgets.QWidget()))
+#                         commands.append(CommandType(widget.setCellWidget, i, j, QtWidgets.QWidget()))
 #
 #         self._widget_children = [child.component for child in children]
 #         for i, child in enumerate(children):
 #             if child.component not in self._already_rendered:
 #                 for j, el in enumerate(child.children):
-#                     commands.append(_CommandType(widget.setCellWidget, i, j, el.component.underlying))
+#                     commands.append(CommandType(widget.setCellWidget, i, j, el.component.underlying))
 #             self._already_rendered[child.component] = True
 #         return commands
 
@@ -1857,13 +1857,13 @@ class ProgressBar(QtWidgetElement):
 
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying)
         if "orientation" in newprops:
-            commands.append(_CommandType(widget.setOrientation, newprops.orientation))
+            commands.append(CommandType(widget.setOrientation, newprops.orientation))
         if "min_value" in newprops:
-            commands.append(_CommandType(widget.setMinimum, newprops.min_value))
+            commands.append(CommandType(widget.setMinimum, newprops.min_value))
         if "max_value" in newprops:
-            commands.append(_CommandType(widget.setMaximum, newprops.max_value))
+            commands.append(CommandType(widget.setMaximum, newprops.max_value))
         if "format" in newprops:
-            commands.append(_CommandType(widget.setFormat, newprops.format))
+            commands.append(CommandType(widget.setFormat, newprops.format))
         if "value" in newprops:
-            commands.append(_CommandType(widget.setValue, newprops.value))
+            commands.append(CommandType(widget.setValue, newprops.value))
         return commands

--- a/edifice/base_components/button_view.py
+++ b/edifice/base_components/button_view.py
@@ -16,7 +16,7 @@ else:
         from PySide6.QtGui import QKeyEvent, QMouseEvent
         from PySide6.QtWidgets import QPushButton, QVBoxLayout, QHBoxLayout
 
-from .base_components import View, _CommandType, QtWidgetElement, Element, _WidgetTree
+from .base_components import View, CommandType, QtWidgetElement, Element, _WidgetTree
 
 
 class _PushButton(QPushButton):
@@ -128,6 +128,6 @@ class ButtonView(View):
         commands = super()._qt_update_commands(widget_trees, newprops)
         for prop in newprops:
             if prop == "on_trigger":
-                commands.append(_CommandType(self._set_on_trigger, self.underlying, newprops.on_trigger))
-            commands.append(_CommandType(self.underlying.setCursor, Qt.CursorShape.PointingHandCursor))
+                commands.append(CommandType(self._set_on_trigger, self.underlying, newprops.on_trigger))
+            commands.append(CommandType(self.underlying.setCursor, Qt.CursorShape.PointingHandCursor))
         return commands

--- a/edifice/base_components/image_aspect.py
+++ b/edifice/base_components/image_aspect.py
@@ -11,7 +11,7 @@ else:
     import PySide6.QtGui as QtGui
     import PySide6.QtWidgets as QtWidgets
 
-from .base_components import QtWidgetElement, _image_descriptor_to_pixmap, _CommandType, Element, _WidgetTree
+from .base_components import QtWidgetElement, _image_descriptor_to_pixmap, CommandType, Element, _WidgetTree
 
 
 class _ScaledLabel(QtWidgets.QLabel):
@@ -120,7 +120,7 @@ class Image(QtWidgetElement):
 
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying, None)
         if "src" in newprops:
-            commands.append(_CommandType(self.underlying._setPixmap, _image_descriptor_to_pixmap(newprops.src)))
+            commands.append(CommandType(self.underlying._setPixmap, _image_descriptor_to_pixmap(newprops.src)))
         if "aspect_ratio_mode" in newprops:
-            commands.append(_CommandType(self.underlying._setAspectRatioMode, newprops.aspect_ratio_mode))
+            commands.append(CommandType(self.underlying._setAspectRatioMode, newprops.aspect_ratio_mode))
         return commands

--- a/edifice/base_components/spin_input.py
+++ b/edifice/base_components/spin_input.py
@@ -9,7 +9,7 @@ else:
     from PySide6.QtGui import QValidator
     from PySide6.QtWidgets import QSpinBox
 
-from .base_components import QtWidgetElement, _CommandType, _ensure_future, Element, _WidgetTree
+from .base_components import QtWidgetElement, CommandType, _ensure_future, Element, _WidgetTree
 
 
 class _SpinBox(QSpinBox):
@@ -150,13 +150,13 @@ class SpinInput(QtWidgetElement):
         commands = super()._qt_update_commands_super(widget_trees, newprops, self.underlying)
 
         if "value_to_text" in newprops:
-            commands.append(_CommandType(setattr, widget, "_textFromValue", newprops.value_to_text))
+            commands.append(CommandType(setattr, widget, "_textFromValue", newprops.value_to_text))
         if "text_to_value" in newprops:
-            commands.append(_CommandType(setattr, widget, "_valueFromText", newprops.text_to_value))
+            commands.append(CommandType(setattr, widget, "_valueFromText", newprops.text_to_value))
         if "min_value" in newprops:
-            commands.append(_CommandType(widget.setMinimum, newprops.min_value))
+            commands.append(CommandType(widget.setMinimum, newprops.min_value))
         if "max_value" in newprops:
-            commands.append(_CommandType(widget.setMaximum, newprops.max_value))
+            commands.append(CommandType(widget.setMaximum, newprops.max_value))
         if "value" in newprops:
-            commands.append(_CommandType(self._set_value, newprops.value))
+            commands.append(CommandType(self._set_value, newprops.value))
         return commands

--- a/edifice/base_components/table_grid_view.py
+++ b/edifice/base_components/table_grid_view.py
@@ -8,7 +8,7 @@ if QT_VERSION == "PyQt6" and not TYPE_CHECKING:
 else:
     from PySide6.QtWidgets import QGridLayout, QWidget
 
-from .base_components import _CommandType, PropsDict, Element, _get_widget_children, _WidgetTree, QtWidgetElement
+from .base_components import CommandType, PropsDict, Element, _get_widget_children, _WidgetTree, QtWidgetElement
 
 logger = logging.getLogger("Edifice")
 
@@ -27,7 +27,7 @@ class _TableGridViewRow(QtWidgetElement):
         self,
         children: list[_WidgetTree],
         newprops: PropsDict,
-    ) -> list[_CommandType]:
+    ) -> list[CommandType]:
         # This element has no Qt underlying so it has nothing to do except store
         # the children of the row.
         # The _qt_update_commands for TableGridView will render the children.
@@ -189,27 +189,27 @@ class TableGridView(QtWidgetElement):
         old_deletions = self._old_children.items() - new_children.items()
         new_additions = new_children.items() - self._old_children.items()
 
-        commands: list[_CommandType] = []
+        commands: list[CommandType] = []
 
         for w, (row, column) in old_deletions:
             if w in new_children:
-                commands.append(_CommandType(self._soft_delete_child, w, row, column))
+                commands.append(CommandType(self._soft_delete_child, w, row, column))
             else:
-                commands.append(_CommandType(self._delete_child, w, row, column))
+                commands.append(CommandType(self._delete_child, w, row, column))
 
         for w, (row, column) in new_additions:
-            commands.append(_CommandType(self._add_child, w, row, column))
+            commands.append(CommandType(self._add_child, w, row, column))
 
         self._old_children = new_children
 
         if "row_stretch" in newprops:
-            commands.append(_CommandType(self._set_row_stretch, newprops["row_stretch"]))
+            commands.append(CommandType(self._set_row_stretch, newprops["row_stretch"]))
         if "column_stretch" in newprops:
-            commands.append(_CommandType(self._set_column_stretch, newprops["column_stretch"]))
+            commands.append(CommandType(self._set_column_stretch, newprops["column_stretch"]))
         if "row_minheight" in newprops:
-            commands.append(_CommandType(self._set_row_minheight, newprops["row_minheight"]))
+            commands.append(CommandType(self._set_row_minheight, newprops["row_minheight"]))
         if "column_minwidth" in newprops:
-            commands.append(_CommandType(self._set_column_minwidth, newprops["column_minwidth"]))
+            commands.append(CommandType(self._set_column_minwidth, newprops["column_minwidth"]))
 
         commands.extend(
             super()._qt_update_commands_super(widget_trees, newprops, self.underlying, self.underlying_layout)

--- a/edifice/engine.py
+++ b/edifice/engine.py
@@ -49,10 +49,10 @@ def _ensure_future(fn):
     return fn
 
 
-class _CommandType:
+class CommandType:
     def __init__(self, fn: Callable[P, tp.Any], *args: P.args, **kwargs: P.kwargs):
         # The return value of fn is ignored and should thus return None. However, in
-        # order to test with equality on the _CommandTypes we need to allow fn to return
+        # order to test with equality on the CommandTypes we need to allow fn to return
         # Any value to not allocate wrapper functions ignoring the return value.
         self.fn = fn
         self.args = args
@@ -65,7 +65,7 @@ class _CommandType:
         return f"{self.fn.__repr__()}(*{self.args.__repr__()},**{self.kwargs.__repr__()})"
 
     def __eq__(self, other):
-        if not isinstance(other, _CommandType):
+        if not isinstance(other, CommandType):
             return False
         if self.fn != other.fn:
             return False
@@ -1139,7 +1139,7 @@ class QtWidgetElement(Element):
         underlying: QtWidgets.QWidget | None,
         underlying_layout: QtWidgets.QLayout | None = None,
     ):
-        commands: list[_CommandType] = []
+        commands: list[CommandType] = []
 
         if underlying_layout is not None:
             set_margin = False
@@ -1185,12 +1185,12 @@ class QtWidgetElement(Element):
 
             if set_margin:
                 commands.append(
-                    _CommandType(
+                    CommandType(
                         underlying_layout.setContentsMargins, new_margin[0], new_margin[1], new_margin[2], new_margin[3]
                     )
                 )
             if set_align:
-                commands.append(_CommandType(underlying_layout.setAlignment, set_align))
+                commands.append(CommandType(underlying_layout.setAlignment, set_align))
         else:
             if "align" in style:
                 if style["align"] == "left":
@@ -1251,11 +1251,11 @@ class QtWidgetElement(Element):
 
         if set_move:
             assert self.underlying is not None
-            commands.append(_CommandType(self.underlying.move, move_coords[0], move_coords[1]))
+            commands.append(CommandType(self.underlying.move, move_coords[0], move_coords[1]))
 
         assert self.underlying is not None
         css_string = _dict_to_style(style, "QWidget#" + str(id(self)))
-        commands.append(_CommandType(self.underlying.setStyleSheet, css_string))
+        commands.append(CommandType(self.underlying.setStyleSheet, css_string))
         return commands
 
     def _set_context_menu(self, underlying: QtWidgets.QWidget):
@@ -1276,7 +1276,7 @@ class QtWidgetElement(Element):
         self,
         widget_trees: dict[Element, "_WidgetTree"],
         newprops: PropsDict,
-    ) -> list[_CommandType]:
+    ) -> list[CommandType]:
         raise NotImplementedError
 
     def _qt_update_commands_super(
@@ -1287,8 +1287,8 @@ class QtWidgetElement(Element):
         newprops: PropsDict,
         underlying: QtWidgets.QWidget,
         underlying_layout: QtWidgets.QLayout | None = None,
-    ) -> list[_CommandType]:
-        commands: list[_CommandType] = []
+    ) -> list[CommandType]:
+        commands: list[CommandType] = []
         for prop in newprops:
             if prop == "style":
                 style = newprops[prop] or {}
@@ -1303,63 +1303,63 @@ class QtWidgetElement(Element):
                 commands.extend(self._gen_styling_commands(style, underlying, underlying_layout))
             elif prop == "size_policy":
                 if newprops.size_policy is not None:
-                    commands.append(_CommandType(underlying.setSizePolicy, newprops.size_policy))
+                    commands.append(CommandType(underlying.setSizePolicy, newprops.size_policy))
             elif prop == "focus_policy":
                 if newprops.focus_policy is not None:
-                    commands.append(_CommandType(underlying.setFocusPolicy, newprops.focus_policy))
+                    commands.append(CommandType(underlying.setFocusPolicy, newprops.focus_policy))
             elif prop == "enabled":
                 if newprops.enabled is not None:
-                    commands.append(_CommandType(underlying.setEnabled, newprops.enabled))
+                    commands.append(CommandType(underlying.setEnabled, newprops.enabled))
             elif prop == "on_click":
-                commands.append(_CommandType(self._set_on_click, underlying, newprops.on_click))
+                commands.append(CommandType(self._set_on_click, underlying, newprops.on_click))
                 if newprops.on_click is not None and self.props.cursor is not None:
-                    commands.append(_CommandType(underlying.setCursor, QtCore.Qt.CursorShape.PointingHandCursor))
+                    commands.append(CommandType(underlying.setCursor, QtCore.Qt.CursorShape.PointingHandCursor))
             elif prop == "on_key_down":
-                commands.append(_CommandType(self._set_on_key_down, underlying, newprops.on_key_down))
+                commands.append(CommandType(self._set_on_key_down, underlying, newprops.on_key_down))
             elif prop == "on_key_up":
-                commands.append(_CommandType(self._set_on_key_up, underlying, newprops.on_key_up))
+                commands.append(CommandType(self._set_on_key_up, underlying, newprops.on_key_up))
             elif prop == "on_mouse_down":
-                commands.append(_CommandType(self._set_on_mouse_down, underlying, newprops.on_mouse_down))
+                commands.append(CommandType(self._set_on_mouse_down, underlying, newprops.on_mouse_down))
             elif prop == "on_mouse_up":
-                commands.append(_CommandType(self._set_on_mouse_up, underlying, newprops.on_mouse_up))
+                commands.append(CommandType(self._set_on_mouse_up, underlying, newprops.on_mouse_up))
             elif prop == "on_mouse_enter":
-                commands.append(_CommandType(self._set_on_mouse_enter, underlying, newprops.on_mouse_enter))
+                commands.append(CommandType(self._set_on_mouse_enter, underlying, newprops.on_mouse_enter))
             elif prop == "on_mouse_leave":
-                commands.append(_CommandType(self._set_on_mouse_leave, underlying, newprops.on_mouse_leave))
+                commands.append(CommandType(self._set_on_mouse_leave, underlying, newprops.on_mouse_leave))
             elif prop == "on_mouse_move":
-                commands.append(_CommandType(self._set_on_mouse_move, underlying, newprops.on_mouse_move))
+                commands.append(CommandType(self._set_on_mouse_move, underlying, newprops.on_mouse_move))
             elif prop == "on_drop":
-                commands.append(_CommandType(self._set_on_drop, underlying, newprops.on_drop))
+                commands.append(CommandType(self._set_on_drop, underlying, newprops.on_drop))
             elif prop == "on_resize":
-                commands.append(_CommandType(self._set_on_resize, newprops.on_resize))
+                commands.append(CommandType(self._set_on_resize, newprops.on_resize))
             elif prop == "tool_tip":
                 if newprops.tool_tip is not None:
-                    commands.append(_CommandType(underlying.setToolTip, newprops.tool_tip))
+                    commands.append(CommandType(underlying.setToolTip, newprops.tool_tip))
             elif prop == "css_class":
                 css_class = newprops.css_class
                 if css_class is None:
                     css_class = []
-                commands.append(_CommandType(underlying.setProperty, "css_class", css_class))
+                commands.append(CommandType(underlying.setProperty, "css_class", css_class))
                 commands.extend(
                     [
-                        _CommandType(underlying.style().unpolish, underlying),
-                        _CommandType(underlying.style().polish, underlying),
+                        CommandType(underlying.style().unpolish, underlying),
+                        CommandType(underlying.style().polish, underlying),
                     ]
                 )
             elif prop == "cursor":
                 cursor = self.props.cursor or ("default" if self.props.on_click is None else "pointer")
-                commands.append(_CommandType(underlying.setCursor, _CURSORS[cursor]))
+                commands.append(CommandType(underlying.setCursor, _CURSORS[cursor]))
             elif prop == "context_menu":
                 if self._context_menu_connected:
                     underlying.customContextMenuRequested.disconnect()
                 if self.props.context_menu is not None:
                     commands.append(
-                        _CommandType(underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
+                        CommandType(underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
                     )
-                    commands.append(_CommandType(self._set_context_menu, underlying))
+                    commands.append(CommandType(self._set_context_menu, underlying))
                 else:
                     commands.append(
-                        _CommandType(underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu)
+                        CommandType(underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu)
                     )
         return commands
 
@@ -1412,9 +1412,9 @@ class RenderResult(object):
 
     def __init__(
         self,
-        commands: list[_CommandType],
+        commands: list[CommandType],
     ):
-        self.commands: list[_CommandType] = commands
+        self.commands: list[CommandType] = commands
 
 
 @dataclass
@@ -1887,11 +1887,11 @@ class RenderEngine(object):
 
         return render_context.widget_tree[component]
 
-    def gen_qt_commands(self, element: QtWidgetElement, render_context: _RenderContext) -> list[_CommandType]:
+    def gen_qt_commands(self, element: QtWidgetElement, render_context: _RenderContext) -> list[CommandType]:
         """
         Recursively generate the update commands for the widget tree.
         """
-        commands: list[_CommandType] = []
+        commands: list[CommandType] = []
         if self.is_stopped:
             return commands
 
@@ -1933,7 +1933,7 @@ class RenderEngine(object):
                         components_.append(element)
                 hook.updaters.clear()
 
-        all_commands: list[_CommandType] = []
+        all_commands: list[CommandType] = []
 
         # Here is the problem.
         # We need to render the child before parent if the child state changed.
@@ -1941,7 +1941,7 @@ class RenderEngine(object):
         # So we do a complete render of each component individually, and then
         # we don't have to solve the problem of the order of rendering.
         for component in components_:
-            commands: list[_CommandType] = []
+            commands: list[CommandType] = []
 
             render_context = _RenderContext(self)
             local_state.render_context = render_context

--- a/edifice/extra/matplotlib_figure.py
+++ b/edifice/extra/matplotlib_figure.py
@@ -1,5 +1,5 @@
 import typing as tp
-from ..base_components.base_components import _CommandType, QtWidgetElement
+from ..base_components.base_components import CommandType, QtWidgetElement
 
 from ..qt import QT_VERSION
 
@@ -82,7 +82,7 @@ class MatplotlibFigure(QtWidgetElement):
                 # alternately we could do draw_idle() here, but I don't think it's
                 # any better and it messes up the mouse events.
 
-            commands.append(_CommandType(_command_plot_fun, self))
+            commands.append(CommandType(_command_plot_fun, self))
         if "on_figure_mouse_move" in newprops:
 
             def _command_mouse_move(self):
@@ -95,5 +95,5 @@ class MatplotlibFigure(QtWidgetElement):
                 else:
                     self.on_mouse_move_connect_id = None
 
-            commands.append(_CommandType(_command_mouse_move, self))
+            commands.append(CommandType(_command_mouse_move, self))
         return commands

--- a/edifice/extra/pyqtgraph_plot.py
+++ b/edifice/extra/pyqtgraph_plot.py
@@ -1,5 +1,5 @@
 import typing as tp
-from ..base_components.base_components import _CommandType, QtWidgetElement
+from ..base_components.base_components import CommandType, QtWidgetElement
 
 # Import PySide6 or PyQt6 before importing pyqtgraph so that pyqtgraph detects the same
 from ..qt import QT_VERSION
@@ -98,6 +98,6 @@ class PyQtPlot(QtWidgetElement):
                 plot_item.clear()
                 plot_fun(plot_item)
 
-            commands.append(_CommandType(_update_plot))
+            commands.append(CommandType(_update_plot))
 
         return commands

--- a/tests/test_base_component.py
+++ b/tests/test_base_component.py
@@ -7,7 +7,7 @@ import unittest
 import unittest.mock
 import edifice.engine as engine
 import edifice.base_components.base_components as base_components
-from edifice.engine import _CommandType
+from edifice.engine import CommandType
 import edifice.icons
 
 from edifice.qt import QT_VERSION
@@ -70,8 +70,8 @@ class StyleTestCase(unittest.TestCase):
         self.assertTrue("margin" not in style)
         self.assertCountEqual(
             commands,
-            [_CommandType(layout.setContentsMargins, 10, 5, 5, 5),
-             _CommandType(comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
+            [CommandType(layout.setContentsMargins, 10, 5, 5, 5),
+             CommandType(comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
         )
 
         style = {
@@ -86,8 +86,8 @@ class StyleTestCase(unittest.TestCase):
         self.assertTrue("margin" not in style)
         self.assertCountEqual(
             commands,
-            [_CommandType(layout.setContentsMargins, 10, 9, 8, 9),
-             _CommandType(comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
+            [CommandType(layout.setContentsMargins, 10, 9, 8, 9),
+             CommandType(comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
         )
 
     def test_align_layout(self):
@@ -106,8 +106,8 @@ class StyleTestCase(unittest.TestCase):
             self.assertTrue("align" not in style)
             self.assertCountEqual(
                 commands,
-                [_CommandType(layout.setAlignment, qt_align),
-                 _CommandType(comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
+                [CommandType(layout.setAlignment, qt_align),
+                 CommandType(comp.underlying.setStyleSheet, "QWidget#%s{}" % id(comp))]
             )
         _test_for_align("left", QtCore.Qt.AlignmentFlag.AlignLeft)
         _test_for_align("right", QtCore.Qt.AlignmentFlag.AlignRight)
@@ -149,7 +149,7 @@ class StyleTestCase(unittest.TestCase):
         }
         comp = MockElement(style=style)
         commands = comp._gen_styling_commands(style, None, None)
-        self.assertTrue(_CommandType(comp.underlying.move, 24, 12) in commands)
+        self.assertTrue(CommandType(comp.underlying.move, 24, 12) in commands)
 
 
 class MockRenderContext(engine._RenderContext):
@@ -175,23 +175,23 @@ class WidgetTreeTestCase(unittest.TestCase):
         qt_button.font().pointSize()
         self.assertCountEqual(
             commands,
-            [_CommandType(qt_button.setText, button_str),
-             _CommandType(qt_button.setStyleSheet, "QWidget#%s{}" % id(button)),
-             _CommandType(qt_button.setProperty, "css_class", []),
-             _CommandType(style.unpolish, qt_button),
-             _CommandType(style.polish, qt_button),
-             _CommandType(button._set_on_click, qt_button, on_click),
-             _CommandType(button._set_on_key_down, qt_button, None),
-             _CommandType(button._set_on_key_up, qt_button, None),
-             _CommandType(button._set_on_mouse_enter, qt_button, None),
-             _CommandType(button._set_on_mouse_leave, qt_button, None),
-             _CommandType(button._set_on_mouse_down, qt_button, None),
-             _CommandType(button._set_on_mouse_up, qt_button, None),
-             _CommandType(button._set_on_mouse_move, qt_button, None),
-             _CommandType(button._set_on_drop, qt_button, None),
-             _CommandType(qt_button.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-             _CommandType(qt_button.setCursor, QtCore.Qt.CursorShape.PointingHandCursor),
-             _CommandType(button._set_on_resize, None)
+            [CommandType(qt_button.setText, button_str),
+             CommandType(qt_button.setStyleSheet, "QWidget#%s{}" % id(button)),
+             CommandType(qt_button.setProperty, "css_class", []),
+             CommandType(style.unpolish, qt_button),
+             CommandType(style.polish, qt_button),
+             CommandType(button._set_on_click, qt_button, on_click),
+             CommandType(button._set_on_key_down, qt_button, None),
+             CommandType(button._set_on_key_up, qt_button, None),
+             CommandType(button._set_on_mouse_enter, qt_button, None),
+             CommandType(button._set_on_mouse_leave, qt_button, None),
+             CommandType(button._set_on_mouse_down, qt_button, None),
+             CommandType(button._set_on_mouse_up, qt_button, None),
+             CommandType(button._set_on_mouse_move, qt_button, None),
+             CommandType(button._set_on_drop, qt_button, None),
+             CommandType(qt_button.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+             CommandType(qt_button.setCursor, QtCore.Qt.CursorShape.PointingHandCursor),
+             CommandType(button._set_on_resize, None)
             ])
 
     def test_view_layout(self):
@@ -222,23 +222,23 @@ class WidgetTreeTestCase(unittest.TestCase):
         assert icon.underlying is not None
         self.assertCountEqual(
             commands,
-            [_CommandType(icon._render_image, *render_img_args),
-             _CommandType(qt_icon.setStyleSheet, "QWidget#%s{}" % id(icon)),
-             _CommandType(qt_icon.setProperty, "css_class", []),
-             _CommandType(style.unpolish, icon.underlying),
-             _CommandType(style.polish, icon.underlying),
-             _CommandType(qt_icon.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-             _CommandType(qt_icon.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
-             _CommandType(icon._set_on_key_down, icon.underlying, None),
-             _CommandType(icon._set_on_key_up, icon.underlying, None),
-             _CommandType(icon._set_on_mouse_enter, icon.underlying, None),
-             _CommandType(icon._set_on_mouse_leave, icon.underlying, None),
-             _CommandType(icon._set_on_mouse_down, icon.underlying, None),
-             _CommandType(icon._set_on_mouse_up, icon.underlying, None),
-             _CommandType(icon._set_on_mouse_move, icon.underlying, None),
-             _CommandType(icon._set_on_click, icon.underlying, None),
-             _CommandType(icon._set_on_drop, icon.underlying, None),
-             _CommandType(icon._set_on_resize, None),
+            [CommandType(icon._render_image, *render_img_args),
+             CommandType(qt_icon.setStyleSheet, "QWidget#%s{}" % id(icon)),
+             CommandType(qt_icon.setProperty, "css_class", []),
+             CommandType(style.unpolish, icon.underlying),
+             CommandType(style.polish, icon.underlying),
+             CommandType(qt_icon.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+             CommandType(qt_icon.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
+             CommandType(icon._set_on_key_down, icon.underlying, None),
+             CommandType(icon._set_on_key_up, icon.underlying, None),
+             CommandType(icon._set_on_mouse_enter, icon.underlying, None),
+             CommandType(icon._set_on_mouse_leave, icon.underlying, None),
+             CommandType(icon._set_on_mouse_down, icon.underlying, None),
+             CommandType(icon._set_on_mouse_up, icon.underlying, None),
+             CommandType(icon._set_on_mouse_move, icon.underlying, None),
+             CommandType(icon._set_on_click, icon.underlying, None),
+             CommandType(icon._set_on_drop, icon.underlying, None),
+             CommandType(icon._set_on_resize, None),
             ])
         icon._render_image(*render_img_args)
 
@@ -260,23 +260,23 @@ class WidgetTreeTestCase(unittest.TestCase):
         label1.underlying.font().pointSize()
 
         commands_expected = label1_commands + [
-            _CommandType(view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
-            _CommandType(view.underlying.setProperty, "css_class", []),
-            _CommandType(view.underlying.style().unpolish, view.underlying),
-            _CommandType(view.underlying.style().polish, view.underlying),
-            _CommandType(view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-            _CommandType(view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
-            _CommandType(view._set_on_key_down, view.underlying, None),
-            _CommandType(view._set_on_key_up, view.underlying, None),
-            _CommandType(view._set_on_mouse_enter, view.underlying, None),
-            _CommandType(view._set_on_mouse_leave, view.underlying, None),
-            _CommandType(view._set_on_mouse_down, view.underlying, None),
-            _CommandType(view._set_on_mouse_up, view.underlying, None),
-            _CommandType(view._set_on_mouse_move, view.underlying, None),
-            _CommandType(view._set_on_click, view.underlying, None),
-            _CommandType(view._set_on_drop, view.underlying, None),
-            _CommandType(view._add_child, 0, label1.underlying),
-            _CommandType(view._set_on_resize, None),
+            CommandType(view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
+            CommandType(view.underlying.setProperty, "css_class", []),
+            CommandType(view.underlying.style().unpolish, view.underlying),
+            CommandType(view.underlying.style().polish, view.underlying),
+            CommandType(view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+            CommandType(view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
+            CommandType(view._set_on_key_down, view.underlying, None),
+            CommandType(view._set_on_key_up, view.underlying, None),
+            CommandType(view._set_on_mouse_enter, view.underlying, None),
+            CommandType(view._set_on_mouse_leave, view.underlying, None),
+            CommandType(view._set_on_mouse_down, view.underlying, None),
+            CommandType(view._set_on_mouse_up, view.underlying, None),
+            CommandType(view._set_on_mouse_move, view.underlying, None),
+            CommandType(view._set_on_click, view.underlying, None),
+            CommandType(view._set_on_drop, view.underlying, None),
+            CommandType(view._add_child, 0, label1.underlying),
+            CommandType(view._set_on_resize, None),
         ]
 
         self.assertCountEqual(commands, commands_expected)
@@ -284,23 +284,23 @@ class WidgetTreeTestCase(unittest.TestCase):
         context.widget_tree[view] = engine._WidgetTree(view, [label1, label2])
         commands = eng.gen_qt_commands(view, context)
         commands_expected = label1_commands + label2_commands + [
-            _CommandType(view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
-            _CommandType(view.underlying.setProperty, "css_class", []),
-            _CommandType(view.underlying.style().unpolish, view.underlying),
-            _CommandType(view.underlying.style().polish, view.underlying),
-            _CommandType(view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-            _CommandType(view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
-            _CommandType(view._set_on_key_down, view.underlying, None),
-            _CommandType(view._set_on_key_up, view.underlying, None),
-            _CommandType(view._set_on_mouse_enter, view.underlying, None),
-            _CommandType(view._set_on_mouse_leave, view.underlying, None),
-            _CommandType(view._set_on_mouse_down, view.underlying, None),
-            _CommandType(view._set_on_mouse_up, view.underlying, None),
-            _CommandType(view._set_on_mouse_move, view.underlying, None),
-            _CommandType(view._set_on_click, view.underlying, None),
-            _CommandType(view._set_on_drop, view.underlying, None),
-            _CommandType(view._add_child, 1, label2.underlying),
-            _CommandType(view._set_on_resize, None),
+            CommandType(view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
+            CommandType(view.underlying.setProperty, "css_class", []),
+            CommandType(view.underlying.style().unpolish, view.underlying),
+            CommandType(view.underlying.style().polish, view.underlying),
+            CommandType(view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+            CommandType(view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
+            CommandType(view._set_on_key_down, view.underlying, None),
+            CommandType(view._set_on_key_up, view.underlying, None),
+            CommandType(view._set_on_mouse_enter, view.underlying, None),
+            CommandType(view._set_on_mouse_leave, view.underlying, None),
+            CommandType(view._set_on_mouse_down, view.underlying, None),
+            CommandType(view._set_on_mouse_up, view.underlying, None),
+            CommandType(view._set_on_mouse_move, view.underlying, None),
+            CommandType(view._set_on_click, view.underlying, None),
+            CommandType(view._set_on_drop, view.underlying, None),
+            CommandType(view._add_child, 1, label2.underlying),
+            CommandType(view._set_on_resize, None),
         ]
         self.assertCountEqual(commands, commands_expected)
 
@@ -309,42 +309,42 @@ class WidgetTreeTestCase(unittest.TestCase):
         context.widget_tree[view] = engine._WidgetTree(view, [label2, inner_view])
         commands = eng.gen_qt_commands(view, context)
         commands_expected = label2_commands + [
-                _CommandType(view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
-                _CommandType(view.underlying.setProperty, "css_class", []),
-                _CommandType(view.underlying.style().unpolish, view.underlying),
-                _CommandType(view.underlying.style().polish, view.underlying),
-                _CommandType(view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-                _CommandType(view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
-                _CommandType(view._set_on_key_down, view.underlying, None),
-                _CommandType(view._set_on_key_up, view.underlying, None),
-                _CommandType(view._set_on_mouse_enter, view.underlying, None),
-                _CommandType(view._set_on_mouse_leave, view.underlying, None),
-                _CommandType(view._set_on_mouse_down, view.underlying, None),
-                _CommandType(view._set_on_mouse_up, view.underlying, None),
-                _CommandType(view._set_on_mouse_move, view.underlying, None),
-                _CommandType(view._set_on_click, view.underlying, None),
-                _CommandType(view._set_on_drop, view.underlying, None),
-                _CommandType(view._set_on_resize, None),
-                _CommandType(inner_view.underlying.setStyleSheet, "QWidget#%s{}" % id(inner_view)),
-                _CommandType(inner_view.underlying.setProperty, "css_class", []),
-                _CommandType(inner_view.underlying.style().unpolish, inner_view.underlying),
-                _CommandType(inner_view.underlying.style().polish, inner_view.underlying),
-                _CommandType(inner_view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
-                _CommandType(inner_view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
-                _CommandType(inner_view._set_on_key_down, inner_view.underlying, None),
-                _CommandType(inner_view._set_on_key_up, inner_view.underlying, None),
-                _CommandType(inner_view._set_on_mouse_enter, inner_view.underlying, None),
-                _CommandType(inner_view._set_on_mouse_leave, inner_view.underlying, None),
-                _CommandType(inner_view._set_on_mouse_down, inner_view.underlying, None),
-                _CommandType(inner_view._set_on_mouse_up, inner_view.underlying, None),
-                _CommandType(inner_view._set_on_mouse_move, inner_view.underlying, None),
-                _CommandType(inner_view._set_on_click, inner_view.underlying, None),
-                _CommandType(inner_view._set_on_drop, inner_view.underlying, None),
-                _CommandType(inner_view._set_on_resize, None),
-                _CommandType(view._soft_delete_child, 1, label2),
-                _CommandType(view._delete_child, 0, label1),
-                _CommandType(view._add_child, 0, label2.underlying),
-                _CommandType(view._add_child, 1, inner_view.underlying),
+                CommandType(view.underlying.setStyleSheet, "QWidget#%s{}" % id(view)),
+                CommandType(view.underlying.setProperty, "css_class", []),
+                CommandType(view.underlying.style().unpolish, view.underlying),
+                CommandType(view.underlying.style().polish, view.underlying),
+                CommandType(view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+                CommandType(view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
+                CommandType(view._set_on_key_down, view.underlying, None),
+                CommandType(view._set_on_key_up, view.underlying, None),
+                CommandType(view._set_on_mouse_enter, view.underlying, None),
+                CommandType(view._set_on_mouse_leave, view.underlying, None),
+                CommandType(view._set_on_mouse_down, view.underlying, None),
+                CommandType(view._set_on_mouse_up, view.underlying, None),
+                CommandType(view._set_on_mouse_move, view.underlying, None),
+                CommandType(view._set_on_click, view.underlying, None),
+                CommandType(view._set_on_drop, view.underlying, None),
+                CommandType(view._set_on_resize, None),
+                CommandType(inner_view.underlying.setStyleSheet, "QWidget#%s{}" % id(inner_view)),
+                CommandType(inner_view.underlying.setProperty, "css_class", []),
+                CommandType(inner_view.underlying.style().unpolish, inner_view.underlying),
+                CommandType(inner_view.underlying.style().polish, inner_view.underlying),
+                CommandType(inner_view.underlying.setContextMenuPolicy, QtCore.Qt.ContextMenuPolicy.DefaultContextMenu),
+                CommandType(inner_view.underlying.setCursor, QtCore.Qt.CursorShape.ArrowCursor),
+                CommandType(inner_view._set_on_key_down, inner_view.underlying, None),
+                CommandType(inner_view._set_on_key_up, inner_view.underlying, None),
+                CommandType(inner_view._set_on_mouse_enter, inner_view.underlying, None),
+                CommandType(inner_view._set_on_mouse_leave, inner_view.underlying, None),
+                CommandType(inner_view._set_on_mouse_down, inner_view.underlying, None),
+                CommandType(inner_view._set_on_mouse_up, inner_view.underlying, None),
+                CommandType(inner_view._set_on_mouse_move, inner_view.underlying, None),
+                CommandType(inner_view._set_on_click, inner_view.underlying, None),
+                CommandType(inner_view._set_on_drop, inner_view.underlying, None),
+                CommandType(inner_view._set_on_resize, None),
+                CommandType(view._soft_delete_child, 1, label2),
+                CommandType(view._delete_child, 0, label1),
+                CommandType(view._add_child, 0, label2.underlying),
+                CommandType(view._add_child, 1, inner_view.underlying),
             ]
         self.assertCountEqual(commands, commands_expected)
 

--- a/tests/test_edifice.py
+++ b/tests/test_edifice.py
@@ -1,7 +1,7 @@
 import unittest
 import unittest.mock
 from edifice import Element, Reference, component, use_ref
-from edifice.engine import _CommandType, _dereference_tree, _WidgetTree, QtWidgetElement
+from edifice.engine import CommandType, _dereference_tree, _WidgetTree, QtWidgetElement
 import edifice.engine as engine
 import edifice.base_components as base_components
 
@@ -232,7 +232,7 @@ class RenderTestCase(unittest.TestCase):
 
         def V(*args):
             view = _dereference_tree(app._widget_tree, qt_tree, list(args))
-            return [_CommandType(view.component._add_child, i, child.underlying)
+            return [CommandType(view.component._add_child, i, child.underlying)
                     for (i, child) in enumerate(view.children)]
 
         expected_commands = C(0, 0) + C(0, 1) + V(0) + C(0) + C(1, 0) + C(1, 1) + V(1) + C(1) + C(2) + V() + C()
@@ -263,21 +263,21 @@ class RenderTestCase(unittest.TestCase):
         qt_tree = app._widget_tree[component]
         qt_commands = render_result.commands
         # TODO: Make it so that only the label (0, 0) needs to update!
-        expected_commands = [_CommandType(_dereference_tree(app._widget_tree, qt_tree, [0, 0]).component.underlying.setText, "AChanged")]
+        expected_commands = [CommandType(_dereference_tree(app._widget_tree, qt_tree, [0, 0]).component.underlying.setText, "AChanged")]
         self.assertEqual(qt_commands, expected_commands)
 
         component.state_b = "BChanged"
         render_result = app._request_rerender([component])
         qt_tree = app._widget_tree[component]
         qt_commands = render_result.commands
-        expected_commands = [_CommandType(_dereference_tree(app._widget_tree, qt_tree, [1, 0]).component.underlying.setText, "BChanged")]
+        expected_commands = [CommandType(_dereference_tree(app._widget_tree, qt_tree, [1, 0]).component.underlying.setText, "BChanged")]
         self.assertEqual(qt_commands, expected_commands)
 
         component.state_c = "CChanged"
         render_result = app._request_rerender([component])
         qt_tree = app._widget_tree[component]
         qt_commands = render_result.commands
-        expected_commands = [_CommandType(_dereference_tree(app._widget_tree, qt_tree, [2]).component.underlying.setText, "CChanged")]
+        expected_commands = [CommandType(_dereference_tree(app._widget_tree, qt_tree, [2]).component.underlying.setText, "CChanged")]
 
         self.assertEqual(qt_commands, expected_commands)
 
@@ -295,7 +295,7 @@ class RenderTestCase(unittest.TestCase):
 
         def new_V(*args):
             view = _dereference_tree(app._widget_tree, _new_qt_tree, args)
-            return [_CommandType(view.component._add_child, i, child.underlying)
+            return [CommandType(view.component._add_child, i, child.underlying)
                     for (i, child) in enumerate(view.children)]
 
         self.assertEqual(_dereference_tree(app._widget_tree, _new_qt_tree, [2, 0]).component.props.text, "D")
@@ -303,9 +303,9 @@ class RenderTestCase(unittest.TestCase):
             return _commands_for_address(app._widget_tree, _new_qt_tree, args)
         expected_commands = (new_C(2, 0) + new_C(2, 1) + new_V(2) + new_C(2) +
             [
-                _CommandType(qt_tree.component._soft_delete_child, 2, _new_qt_tree.children[3]),
-                _CommandType(qt_tree.component._add_child, 2, _new_qt_tree.children[2].underlying),
-                _CommandType(qt_tree.component._add_child, 3, _new_qt_tree.children[3].underlying),
+                CommandType(qt_tree.component._soft_delete_child, 2, _new_qt_tree.children[3]),
+                CommandType(qt_tree.component._add_child, 2, _new_qt_tree.children[2].underlying),
+                CommandType(qt_tree.component._add_child, 3, _new_qt_tree.children[3].underlying),
             ])
 
         # Disabling this test.
@@ -329,10 +329,10 @@ class RenderTestCase(unittest.TestCase):
         qt_commands = render_result.commands
 
         expected_commands = ([
-            _CommandType(qt_tree.component._soft_delete_child, 2, qt_tree.children[2]),
-            _CommandType(qt_tree.component._soft_delete_child, 0, qt_tree.children[0]),
-            _CommandType(qt_tree.component._add_child, 0, qt_tree.children[2].underlying),
-            _CommandType(qt_tree.component._add_child, 2, qt_tree.children[0].underlying),
+            CommandType(qt_tree.component._soft_delete_child, 2, qt_tree.children[2]),
+            CommandType(qt_tree.component._soft_delete_child, 0, qt_tree.children[0]),
+            CommandType(qt_tree.component._add_child, 0, qt_tree.children[2].underlying),
+            CommandType(qt_tree.component._add_child, 2, qt_tree.children[0].underlying),
         ])
 
         self.assertEqual(qt_commands, expected_commands)
@@ -349,8 +349,8 @@ class RenderTestCase(unittest.TestCase):
         qt_commands = render_result.commands
 
         expected_commands = [
-            _CommandType(_dereference_tree(app._widget_tree, qt_tree, [0, 0]).component.underlying.setText, "C"),
-            _CommandType(_dereference_tree(app._widget_tree, qt_tree, [2, 0]).component.underlying.setText, "A"),
+            CommandType(_dereference_tree(app._widget_tree, qt_tree, [0, 0]).component.underlying.setText, "C"),
+            CommandType(_dereference_tree(app._widget_tree, qt_tree, [2, 0]).component.underlying.setText, "A"),
         ]
         self.assertEqual(qt_commands, expected_commands)
 
@@ -366,7 +366,7 @@ class RenderTestCase(unittest.TestCase):
         _new_qt_tree = app._widget_tree[component]
         qt_commands = render_result.commands
 
-        expected_commands = [_CommandType(app._widget_tree[component].component._delete_child, 2, old_child)]
+        expected_commands = [CommandType(app._widget_tree[component].component._delete_child, 2, old_child)]
 
         self.assertEqual(qt_commands, expected_commands)
 
@@ -612,7 +612,7 @@ class RefreshClassTestCase(unittest.TestCase):
         commands = v._recompute_children(new_children)
         self.assertEqual(
             commands,
-            [ _CommandType(v._delete_child, 2, children1[2]),
+            [ CommandType(v._delete_child, 2, children1[2]),
             ],
         )
 
@@ -626,10 +626,10 @@ class RefreshClassTestCase(unittest.TestCase):
         self.assertEqual(
             commands,
             [
-                _CommandType(v._soft_delete_child, 2, children1[2]),
-                _CommandType(v._soft_delete_child, 0, children1[0]),
-                _CommandType(v._add_child, 0, children1[2].underlying),
-                _CommandType(v._add_child, 2, children1[0].underlying),
+                CommandType(v._soft_delete_child, 2, children1[2]),
+                CommandType(v._soft_delete_child, 0, children1[0]),
+                CommandType(v._add_child, 0, children1[2].underlying),
+                CommandType(v._add_child, 2, children1[0].underlying),
             ],
         )
 


### PR DESCRIPTION
`_CommandType` is needed when implementing custom `ed.QtWidgetElement` elements and generating the commands inside `_qt_update_commands` . Therefore, this PR changes `_CommandType` to `CommandType` so that it can be recognized by linters as non-private.