### PR TITLE
Use `magin` instead of `padding` in the examples

### DIFF
--- a/examples/calculator.py
+++ b/examples/calculator.py
@@ -32,7 +32,7 @@ button_style = {"font-size": 20, "color": "white", "height": 46, "width": 60, "b
 digits_style = button_style | {"background-color": "#777777"}
 binary_style = button_style | {"background-color": "#ff9e00", "font-size": 30}
 unary_style = button_style | {"background-color": "#595959"}
-display_style = {"font-size": 50, "height": 70, "color": "white", "width": 240, "align": "right", "padding-right": 10}
+display_style = {"font-size": 50, "height": 70, "color": "white", "width": 240, "align": "right", "margin-right": 10}
 
 @ed.component
 def Calculator(self):

--- a/examples/financial_charts.py
+++ b/examples/financial_charts.py
@@ -90,7 +90,7 @@ def AxisDescriptor(
                 on_select=handle_data_type,
             )
             if data_type != "Date":
-                TextInput( text=ticker, style={"padding": 2},
+                TextInput( text=ticker, style={"margin": 2},
                     on_change=handle_ticker
                 )
 

--- a/examples/market_data_viewer.py
+++ b/examples/market_data_viewer.py
@@ -11,8 +11,8 @@ import random
 
 stylesheet = dict(
     price_box={
-        "padding-top": 0,
-        "padding": 0,
+        "margin-top": 0,
+        "margin": 0,
         "width": "50px",
         "align": "right",
         "border": "1px solid black",
@@ -20,7 +20,7 @@ stylesheet = dict(
     },
     size_box={
         "color": "rgba(220, 230, 220, 1)", "margin": "0px",
-        "padding": "2px", "top": "0px",
+        "margin": "2px", "top": "0px",
         "align": "right",
         "border-top": "1px solid black",
         "width": "50px",
@@ -29,7 +29,7 @@ stylesheet = dict(
     size_bar={
         "height": "25px",
         "margin-left": "10px",
-        "padding": "2px",
+        "margin": "2px",
         "align": "left",
     },
     play_button={
@@ -61,7 +61,7 @@ def PriceLevel(self, price, size, side, last=False):
         price_box_style["border-bottom"] = "1px solid black"
         size_box_style["border-bottom"] = "1px solid black"
 
-    with ed.View(layout="row", style={"padding": "0px", "width": "360px", "align": "left"}):
+    with ed.View(layout="row", style={"margin": "0px", "width": "360px", "align": "left"}):
         ed.Label(price, style=price_box_style).set_key("price")
         ed.Label(size, style=size_box_style).set_key("size")
         ed.Label("", style=size_bar_style).set_key("vis_size")
@@ -70,7 +70,7 @@ def PriceLevel(self, price, size, side, last=False):
 def Book(self, book):
     sizes = book["sizes"]
     market_price = book["price"]
-    with ed.View(layout="column", style={"margin": "10px", "padding": "0px", "width": 360}):
+    with ed.View(layout="column", style={"margin": "10px", "margin": "0px", "width": 360}):
         for p in range(20, 0, -1):
             PriceLevel(price=p, size=sizes[p],
                         side="bid" if p < market_price else "ask",

--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -27,7 +27,7 @@ def ConversionWidget(self, from_unit, to_unit, factor):
 
     from_label_style = {"width": 170}
     to_label_style = {"margin-left": 60, "width": 200}
-    input_style = {"padding": 2, "width": 120}
+    input_style = {"margin": 2, "width": 120}
     with View(layout="row", style={"margin": 10, "width": 560}):
         Label(f"Measurement in {self.props.from_unit}:", style=from_label_style)
         TextInput(current_text, style=input_style, on_change=current_text_set)

--- a/examples/tutorial_old.py
+++ b/examples/tutorial_old.py
@@ -30,7 +30,7 @@ class ConversionWidget(ed.Element):
 
         from_label_style = {"width": 170}
         to_label_style = {"margin-left": 20, "width": 200}
-        input_style = {"padding": 2, "width": 120}
+        input_style = {"margin": 2, "width": 120}
         return ed.View(layout="row", style={"margin": 10, "width": 560})(
             Label(f"Measurement in {self.props.from_unit}:", style=from_label_style),
             TextInput(from_text, style=input_style,


### PR DESCRIPTION
This PR changes the examples to use `margin` instead of `padding` for styling. It seems like they both have the same effect, however [the documentation](https://pyedifice.github.io/styling.html) only documents `margin`, hence why I thought it would be better to use it in the example.

Another option would be to indicate in the docs that `padding` is an alias for `margin`.