### PR TITLE
provide_context, use_context

### DIFF
--- a/docs/source/hooks.rst
+++ b/docs/source/hooks.rst
@@ -49,6 +49,8 @@ These Derived Hooks are provided by Edifice.
    use_async_call
    use_callback
    use_memo
+   provide_context
+   use_context
    use_hover
    use_stop
 

--- a/edifice/__init__.py
+++ b/edifice/__init__.py
@@ -34,6 +34,7 @@ from edifice.base_components import (
     WindowPopView,
 )
 from edifice.hooks import (
+    provide_context,
     use_async,
     use_async_call,
     use_callback,
@@ -89,6 +90,7 @@ __all__ = [
     "file_dialog",
     "palette_edifice_dark",
     "palette_edifice_light",
+    "provide_context",
     "qt_component",
     "set_trace",
     "theme_is_light",

--- a/examples/use_context1.py
+++ b/examples/use_context1.py
@@ -2,12 +2,12 @@
 # python examples/use_context1.py
 #
 
-from edifice import App, Button, Label, VBoxView, Window, component, use_context
+from edifice import App, Button, Label, VBoxView, Window, component, provide_context, use_context
 
 
 @component
 def Display(self):
-    show, _ = use_context("show", False)
+    show, _ = use_context("show", bool)
     with VBoxView():
         if show:
             TestComp()
@@ -15,7 +15,7 @@ def Display(self):
 
 @component
 def UseContext1(self):
-    show, set_show = use_context("show", False)
+    show, set_show = provide_context("show", False)
     with Window():
         if show:
             with VBoxView():

--- a/examples/use_context2.py
+++ b/examples/use_context2.py
@@ -2,13 +2,13 @@
 # python examples/use_context2.py
 #
 
-from edifice import App, Button, HBoxView, Label, VBoxView, Window, component, use_context
+from edifice import App, Button, HBoxView, Label, VBoxView, Window, component, provide_context, use_context
 
 
 @component
 def Display(self):
-    show_a, _ = use_context("show_a", False)
-    show_c, set_show_c = use_context("show_c", False)
+    show_a, _ = use_context("show_a", bool)
+    show_c, set_show_c = use_context("show_c", bool)
     with VBoxView():
         if show_a:
             TestComp()
@@ -20,9 +20,9 @@ def Display(self):
 
 @component
 def UseContext1(self):
-    show_a, set_show_a = use_context("show_a", False)
-    show_b, set_show_b = use_context("show_b", False)
-    show_c, _ = use_context("show_c", True)
+    show_a, set_show_a = provide_context("show_a", False)
+    show_b, set_show_b = provide_context("show_b", False)
+    show_c, _ = provide_context("show_c", True)
     with Window():
         with VBoxView():
             with HBoxView():

--- a/examples/use_context3.py
+++ b/examples/use_context3.py
@@ -1,0 +1,57 @@
+#
+# python examples/use_context3.py
+#
+
+import edifice as ed
+
+
+@ed.component
+def Display(self):
+    context_select, context_select_set = ed.use_state(0)
+    # This is kind of stupid, no-one should ever dynamically
+    # select the context_key, but we do it here to show that it's possible.
+    text_a, text_a_set = ed.use_context(str(context_select), str)
+    with ed.VBoxView(style={"padding": 10}):
+        ed.Dropdown(
+            selection=context_select,
+            options=("context A", "context B"),
+            on_select=context_select_set,
+        )
+        ed.TextInput(text=text_a, on_change=text_a_set)
+
+
+@ed.component
+def Main(self):
+    show_all, set_show_all = ed.use_state(False)
+
+    with ed.Window(_size_open=(800, 400)):
+        with ed.VBoxView(style={"align": "top"}):
+            ed.CheckBox(text="Show All", checked=show_all, on_change=set_show_all)
+            if show_all:
+                ProviderComponent()
+
+
+@ed.component
+def ProviderComponent(self):
+    show_a, set_show_a = ed.use_state(False)
+    text_a, set_text_a = ed.provide_context("0", "Hello")
+    text_b, set_text_b = ed.provide_context("1", "World")
+    display_count, set_display_count = ed.use_state(10)
+
+    with ed.VBoxView(style={"align": "top"}):
+        with ed.HBoxView():
+            ed.Label(text="Context A")
+            ed.TextInput(text=text_a, on_change=set_text_a)
+            ed.Label(text="Context B")
+            ed.TextInput(text=text_b, on_change=set_text_b)
+        with ed.HBoxView():
+            ed.CheckBox(text="Show Displays", checked=show_a, on_change=set_show_a)
+            ed.SpinInput(value=display_count, on_change=set_display_count)
+        if show_a:
+            with ed.FlowView():
+                for _ in range(display_count):
+                    Display()
+
+
+if __name__ == "__main__":
+    ed.App(Main()).start()

--- a/tests/test_use_context.py
+++ b/tests/test_use_context.py
@@ -1,6 +1,6 @@
 import unittest
 
-from edifice import App, Button, Element, Label, VBoxView, Window, component, use_context
+import edifice as ed
 from edifice.qt import QT_VERSION
 
 if QT_VERSION == "PyQt6":
@@ -13,36 +13,27 @@ if QtWidgets.QApplication.instance() is None:
 
 class IntegrationTestCase(unittest.TestCase):
     def test_use_context1(self):
-        @component
+        @ed.component
         def Display(self):
-            show, _ = use_context("show", False)
-            with VBoxView():
+            show, _ = ed.use_context("show", bool)
+            with ed.VBoxView():
                 if show:
-                    TestComp()
+                    ed.Label(text=str(id(self)))
 
-        @component
+        @ed.component
         def Wrapper(self):
-            show, set_show = use_context("show", False)
-            with Window():
+            ed.use_effect(ed.use_stop(), ()) # render one time then stop
+            show, set_show = ed.provide_context("show", False)
+            with ed.Window():
                 if show:
-                    with VBoxView():
-                        Button(title="Hide", on_click=lambda _ev: set_show(False))
+                    with ed.VBoxView():
+                        ed.Button(title="Hide", on_click=lambda _ev: set_show(False))
                         Display()
                 else:
-                    with VBoxView():
-                        Button(title="Show", on_click=lambda _ev: set_show(True))
+                    with ed.VBoxView():
+                        ed.Button(title="Show", on_click=lambda _ev: set_show(True))
 
-        class TestComp(Element):
-            def __init__(self):
-                super().__init__()
-
-            def _render_element(self):
-                print("TestComp instance " + str(id(self)))
-                return VBoxView(style={"align": "top"})(Label(text=str(id(self))))
-
-        my_app = App(Wrapper(), create_application=False)
-        with my_app.start_loop() as loop:
-            loop.call_later(0.1, my_app.stop)
+        ed.App(Wrapper(), create_application=False).start()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Further work on #104

Expanding on #205, We have split up the `use_context` Hook into two Hooks, `provide_context` and `use_context`.

The `use_context` Hook now takes a type parameter and the user must ensure that it is the same type as the `provide_context` initial value.