### PR TITLE
run_subprocess_with_callback subprocess non-async

### DIFF
--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -7,6 +7,32 @@
 Release Notes
 =============
 
+**Breaking Changes**
+
+- :func:`run_subprocess_with_callback` takes a normal function instead of an
+  :code:`async` coroutine for the :code:`subprocess` argument.
+
+  If you want the :code:`subprocess` to be an :code:`async` function then
+  make a new event loop and use that as the event loop for the Process.
+
+  .. code-block:: python
+      :caption: Example async subprocess function
+
+      def my_subprocess(callback: typing.Callable[[int], None]) -> str:
+
+          async def work() -> str:
+              callback(1)
+              await asyncio.sleep(1)
+              return "done"
+
+          return asyncio.new_event_loop().run_until_complete(work())
+
+  **Migration Guide:**
+
+  Unfortunately Pyright will not error on this change. You must check each
+  :func:`run_subprocess_with_callback` call site and make sure that the
+  :code:`subprocess` argument is a normal function, not an :code:`async` function.
+
 v3.2.3
 ------
 Released: 2025-04-19

--- a/examples/run_subprocess.py
+++ b/examples/run_subprocess.py
@@ -3,21 +3,20 @@
 #
 
 
-import asyncio
-import functools
+import time
 from collections.abc import Callable
 from typing import cast
 
 import edifice as ed
 
 
-async def my_subprocess(
+def my_subprocess(
     callback: Callable[[str], None],
 ) -> None:
     callback("Step 1")
-    await asyncio.sleep(1)
+    time.sleep(1)
     callback("Step 2")
-    await asyncio.sleep(1)
+    time.sleep(1)
     callback("Step 3")
 
 @ed.component

--- a/src/edifice/hooks.py
+++ b/src/edifice/hooks.py
@@ -444,8 +444,8 @@ def use_async(
     Worker Process
     --------------
 
-    We can run an
-    :code:`async def my_subprocess` function in a worker
+    We can run a
+    :code:`def my_subprocess` function in a worker
     `Process <https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process>`_
     by using :func:`run_subprocess_with_callback`.
 
@@ -459,8 +459,8 @@ def use_async(
     .. code-block:: python
         :caption: use_async with run_subprocess_with_callback
 
-        async def my_subprocess(callback: Callable[[str], None]) -> int:
-            # This function will run in a new Process in a new event loop.
+        def my_subprocess(callback: Callable[[str], None]) -> int:
+            # This function will run in a new Process.
             callback("Starting long calculation")
             await asyncio.sleep(100.0)
             x = 1 + 2


### PR DESCRIPTION
Maybe is it better to have a non-async `subprocess` argument to `run_subprocess_with_callback`.

If the `async def subprocess` function never calls `await`, which is a pretty common case, then Ruff will warn.

There is no actual reason why the `subprocess` must be `async`. I just thought it would be nice and convenient that way.