### PR TITLE
Fixed styles not applying for custom widgets.

### DIFF
--- a/src/edifice/base_components/base_components.py
+++ b/src/edifice/base_components/base_components.py
@@ -2683,6 +2683,7 @@ class CustomWidget(QtWidgetElement[_T_customwidget]):
     ):
         if self.underlying is None:
             self.underlying = self.create_widget()
+            self.underlying.setObjectName(str(id(self)))
         commands = super()._qt_update_commands_super(widget_trees, diff_props, self.underlying, None)
         commands.append(CommandType(self.update, self.underlying, diff_props))
         return commands


### PR DESCRIPTION
Fixes the issue as described below in https://github.com/pyedifice/pyedifice/issues/236#issue-3478317403

Adds an object name to apply styles to custom edifice widgets.