### PR TITLE
Bugfix for SpinInput and Slider.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,7 @@ sys.path.append(os.path.abspath("../.."))
 sys.path.append(os.path.abspath("./image"))
 
 project = "Edifice"
-release = "5.0.0"
+release = "5.0.1"
 # Copyright is broken, renders as '1980, David Ding' for some reason
 # project_copyright = '2021, David Ding'
 author = "David Ding, James D. Brock, Viktor Kronvall"

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -7,6 +7,13 @@
 Release Notes
 =============
 
+v5.0.1
+------
+Released: 2026-06-18
+
+- Bugfix: :class:`SpinInput` :code:`max_value` prop default value is applied to the widget as expected.
+- Bugfix: :class:`Slider` :code:`max_value` prop default value is applied to the widget as expected.
+
 v5.0.0
 ------
 Released: 2025-11-30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyedifice"
-version = "5.0.0"
+version = "5.0.1"
 description = "Declarative GUI framework for Python and Qt"
 authors = [
     {name = "David Ding"},

--- a/src/edifice/base_components/base_components.py
+++ b/src/edifice/base_components/base_components.py
@@ -832,6 +832,10 @@ class Slider(QtWidgetElement[QtWidgets.QSlider]):
 
         self.underlying.setObjectName(str(id(self)))
         self.underlying.valueChanged.connect(self._on_change_handle)
+        # The QSlider seems to have the same issue as the QSpinInput for which the default maximum is 99.
+        # So we need to do this in order for default Slider to reach 100. However, I could not find if the 99 maximum is
+        # stated in the Qt documentation.
+        self.underlying.setMaximum(100)
 
     def _on_change_handle(self, position: int) -> None:
         if self._on_change is not None:

--- a/src/edifice/base_components/spin_input.py
+++ b/src/edifice/base_components/spin_input.py
@@ -142,6 +142,10 @@ class SpinInput(QtWidgetElement[EdSpinBox]):
         self.underlying = EdSpinBox()
         self.underlying.setObjectName(str(id(self)))
         self.underlying.valueChanged.connect(self._on_change_handler)
+        # Qt's default max is 99. So if we do not set it, any `SpingInput` created with default
+        # max value will reach only up to 99, not 100.
+        # https://doc.qt.io/qt-6/qspinbox.html#maximum-prop
+        self.underlying.setMaximum(100)
 
     def _on_change_handler(self, value: int):
         if self.props["on_change"] is not None:


### PR DESCRIPTION
Currently, by default `Slider` and `SpinInput` only count up to 99, even though the default value for `max_value` is 100 and it is meant to be inclusive. This PR fixes the issue.